### PR TITLE
fix: add viewport scrolling to log group list to prevent overflow

### DIFF
--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -51,10 +51,11 @@ type Model struct {
 	width  int
 	height int
 
-	logGroups []logs.LogGroup
-	cursor    int
-	selected  map[string]bool
-	loading   bool
+	logGroups  []logs.LogGroup
+	cursor     int
+	listOffset int
+	selected   map[string]bool
+	loading    bool
 
 	searching  bool
 	search     textinput.Model
@@ -109,6 +110,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.setViewportSize(m.bodyHeight())
+		m.ensureCursorVisible()
 	case logGroupsLoadedMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -155,6 +157,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			var cmd tea.Cmd
 			m.search, cmd = m.search.Update(msg)
+			// Reset cursor and offset when filter changes
+			m.cursor = 0
+			m.listOffset = 0
 			return m, cmd
 		}
 
@@ -225,6 +230,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if m.cursor > 0 {
 					m.cursor--
+					m.ensureCursorVisible()
 				}
 			}
 		case "down", "j":
@@ -236,6 +242,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if m.cursor < len(m.filteredGroups())-1 {
 					m.cursor++
+					m.ensureCursorVisible()
 				}
 			}
 		case "/":
@@ -573,4 +580,32 @@ func (m Model) bodyHeight() int {
 		return m.height
 	}
 	return h
+}
+
+func (m Model) listHeight() int {
+	// bodyHeight minus: header(1) + search hint(1) + blank(1) + footer(1) + borders(2)
+	h := m.bodyHeight() - 6
+	if h < 3 {
+		return 3
+	}
+	return h
+}
+
+func (m *Model) ensureCursorVisible() {
+	visibleHeight := m.listHeight()
+	if visibleHeight <= 0 {
+		return
+	}
+
+	if m.cursor < m.listOffset {
+		m.listOffset = m.cursor
+	}
+
+	if m.cursor >= m.listOffset+visibleHeight {
+		m.listOffset = m.cursor - visibleHeight + 1
+	}
+
+	if m.listOffset < 0 {
+		m.listOffset = 0
+	}
 }

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -74,8 +74,22 @@ func (m Model) renderGroups() string {
 		return b.String()
 	}
 
+	visibleHeight := m.listHeight()
+
 	showCursor := !m.tailing || m.focus == panelGroups
-	for i, g := range groups {
+
+	if m.listOffset > 0 {
+		fmt.Fprintln(b, dimText.Render("  ↑ more above"))
+		visibleHeight--
+	}
+
+	endIdx := m.listOffset + visibleHeight
+	if endIdx > len(groups) {
+		endIdx = len(groups)
+	}
+
+	for i := m.listOffset; i < endIdx; i++ {
+		g := groups[i]
 		line := fmt.Sprintf("[%s] %s", checkbox(m.selected[g.Name]), g.Name)
 		if showCursor && i == m.cursor {
 			line = cursorStyle.Render(line)
@@ -83,6 +97,10 @@ func (m Model) renderGroups() string {
 			line = selectedStyle.Render(line)
 		}
 		fmt.Fprintln(b, line)
+	}
+
+	if endIdx < len(groups) {
+		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
 	}
 
 	fmt.Fprintf(b, "\n%s\n", dimText.Render(fmt.Sprintf("Selected: %d | Total: %d", m.selectedCount(), len(m.logGroups))))


### PR DESCRIPTION
The log group list rendered all items without height constraints, causing
overflow when many groups existed. Added listOffset tracking with scroll
indicators (↑/↓) matching the pattern used in the S3 bucket list.

https://claude.ai/code/session_013mBphHM2AhyHKLkoj5Xact