### PR TITLE
fix: correct CloudWatch log group list height calculation to prevent overflow

### DIFF
--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -583,8 +583,8 @@ func (m Model) bodyHeight() int {
 }
 
 func (m Model) listHeight() int {
-	// bodyHeight minus: header(1) + search hint(1) + blank(1) + footer(1) + borders(2)
-	h := m.bodyHeight() - 6
+	// bodyHeight minus: header(1) + search hint(1) + blank(1) + footer(1) + status(1) + borders(2)
+	h := m.bodyHeight() - 7
 	if h < 3 {
 		return 3
 	}
@@ -601,8 +601,18 @@ func (m *Model) ensureCursorVisible() {
 		m.listOffset = m.cursor
 	}
 
-	if m.cursor >= m.listOffset+visibleHeight {
-		m.listOffset = m.cursor - visibleHeight + 1
+	// When scrolled past the top, the "↑ more above" indicator takes one
+	// line from the visible area, so reduce the effective height.
+	effective := visibleHeight
+	if m.listOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
+	if m.cursor >= m.listOffset+effective {
+		m.listOffset = m.cursor - effective + 1
 	}
 
 	if m.listOffset < 0 {


### PR DESCRIPTION
The listHeight() calculation was missing the status line in its
accounting (subtracted 6 instead of 7), causing the rendered content
to overflow the panel when scroll indicators and the status line were
visible simultaneously. Also fix ensureCursorVisible() to account for
the "↑ more above" indicator consuming a line, which could leave the
cursor on an invisible item when scrolled down.

https://claude.ai/code/session_01PecmheXmpuZtnttqZcYpb7