### PR TITLE
feat: complete DynamoDB service with item expansion, copy ARN, and back navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,3 +193,24 @@ Resolution precedence:
 **Preview Mode**
 - `↑/↓` - Scroll
 - `p/esc` - Close preview
+
+### DynamoDB (`internal/ui/dynamodb/`)
+
+**Tables View (default)**
+- `↑/↓` or `j/k` - Navigate (lazy loads more tables near end)
+- `/` - Search/filter
+- `enter` - Open table (scan items)
+- `y` - Copy table ARN
+
+**Items View (inside table)**
+- `↑/↓` or `j/k` - Navigate (lazy loads more items near end)
+- `/` - Search/filter items by value
+- `enter` or `space` - Expand selected item (popup with full attribute details)
+- `y` - Copy table ARN
+- `esc/backspace/h` - Go back to tables list
+
+**Expanded Item Popup**
+- Accessed by pressing `enter` or `space` on a selected item
+- `↑/↓` or `j/k` - Scroll up/down
+- `pgup/pgdn` - Page up/down
+- `esc` - Close popup

--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/sachamama/sacha/internal/dynamodb"
 )
 
@@ -34,6 +37,10 @@ type Model struct {
 	cursor     int
 	listOffset int
 
+	// Expanded item popup
+	expandedItem int            // index of expanded item, -1 if none
+	expandedView viewport.Model // viewport for expanded item
+
 	// UI
 	width      int
 	height     int
@@ -49,9 +56,10 @@ func NewModel(client *dynamodb.Client) Model {
 	ti.Placeholder = "filter"
 	ti.Prompt = "/ "
 	return Model{
-		client:  client,
-		search:  ti,
-		loading: true,
+		client:       client,
+		search:       ti,
+		loading:      true,
+		expandedItem: -1,
 	}
 }
 
@@ -143,6 +151,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Handle expanded item popup
+	if m.expandedItem >= 0 {
+		switch msg.String() {
+		case "esc", "q", "enter":
+			m.expandedItem = -1
+		case "up", "k":
+			m.expandedView.ScrollUp(1)
+		case "down", "j", " ":
+			m.expandedView.ScrollDown(1)
+		case "pgup":
+			m.expandedView.HalfPageUp()
+		case "pgdn":
+			m.expandedView.HalfPageDown()
+		}
+		return m, nil
+	}
+
 	// Handle search input
 	if m.searching {
 		switch msg.Type {
@@ -185,17 +210,47 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
-	case "enter":
-		return m.handleEnter()
-	case "backspace", "esc":
+	case "enter", " ":
+		if m.table != "" {
+			// In items view - expand the selected item
+			items := m.filteredItems()
+			if len(items) > 0 && m.cursor < len(items) {
+				m.expandedItem = m.cursor
+				m.expandedView = initExpandedItemView(items[m.cursor], m.itemColumns, m.width, m.height)
+			}
+			return m, nil
+		}
+		if msg.String() == "enter" {
+			return m.handleEnter()
+		}
+	case "backspace", "esc", "h":
 		return m.handleBack()
 	case "/":
 		m.searching = true
 		m.search.SetValue("")
 		return m, m.search.Focus()
+	case "y":
+		arn := m.getARN()
+		if arn != "" {
+			_ = clipboard.WriteAll(arn)
+			m.statusLine = "Copied: " + arn
+		}
 	}
 
 	return m, nil
+}
+
+func (m Model) getARN() string {
+	if m.table == "" {
+		// In table list - copy table ARN
+		tables := m.filteredTables()
+		if len(tables) == 0 || m.cursor >= len(tables) {
+			return ""
+		}
+		return fmt.Sprintf("arn:aws:dynamodb:*:*:table/%s", tables[m.cursor].Name)
+	}
+	// In items view - copy table ARN
+	return fmt.Sprintf("arn:aws:dynamodb:*:*:table/%s", m.table)
 }
 
 // View renders the model.
@@ -211,7 +266,18 @@ func (m Model) View() string {
 	left := panelStyle.Width(leftWidth - 2).Height(bodyHeight).Render(m.renderLeft())
 	right := panelStyle.Width(rightWidth - 2).Height(bodyHeight).Render(m.renderRight())
 
-	return lipglossJoinHorizontal(left, right)
+	view := lipglossJoinHorizontal(left, right)
+
+	if m.expandedItem >= 0 {
+		items := m.filteredItems()
+		if m.expandedItem < len(items) {
+			popup := m.renderExpandedItem(items[m.expandedItem])
+			view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
+				lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
+		}
+	}
+
+	return view
 }
 
 func (m Model) bodyHeight() int {
@@ -439,11 +505,14 @@ func (m Model) loadMoreItemsCmd() tea.Cmd {
 
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
+	if m.expandedItem >= 0 {
+		return "↑↓ scroll, pgup/pgdn page, esc close"
+	}
 	if m.searching {
 		return "enter/esc close search"
 	}
 	if m.table == "" {
-		return "↑↓ move, / search, enter open"
+		return "↑↓ move, / search, enter open, y copy ARN"
 	}
-	return "↑↓ move, / search, esc back"
+	return "↑↓ move, / search, enter expand, y copy ARN, esc/h back"
 }

--- a/internal/ui/dynamodb/model_test.go
+++ b/internal/ui/dynamodb/model_test.go
@@ -1,0 +1,569 @@
+package dynamodb
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachamama/sacha/internal/dynamodb"
+)
+
+func newTestModel(tables []dynamodb.Table) Model {
+	m := NewModel(nil) // client not needed for direct state tests
+	m.tables = tables
+	m.loading = false
+	m.width = 120
+	m.height = 40
+	return m
+}
+
+func sendKey(m Model, key string) Model {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+	return updated.(Model)
+}
+
+func sendSpecialKey(m Model, keyType tea.KeyType) Model {
+	updated, _ := m.Update(tea.KeyMsg{Type: keyType})
+	return updated.(Model)
+}
+
+func sendMsg(m Model, msg tea.Msg) Model {
+	updated, _ := m.Update(msg)
+	return updated.(Model)
+}
+
+func TestNewModel(t *testing.T) {
+	m := NewModel(nil)
+	if !m.loading {
+		t.Error("expected loading to be true")
+	}
+	if m.expandedItem != -1 {
+		t.Error("expected expandedItem to be -1")
+	}
+	if m.table != "" {
+		t.Error("expected table to be empty")
+	}
+}
+
+func TestTablesLoadedMsg(t *testing.T) {
+	m := newTestModel(nil)
+	m.loading = true
+
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+		{Name: "products"},
+	}
+	m = sendMsg(m, tablesLoadedMsg{tables: tables})
+
+	if m.loading {
+		t.Error("expected loading to be false")
+	}
+	if len(m.tables) != 3 {
+		t.Errorf("expected 3 tables, got %d", len(m.tables))
+	}
+	if m.statusLine != "Loaded 3 tables" {
+		t.Errorf("unexpected status: %q", m.statusLine)
+	}
+}
+
+func TestTablesLoadedError(t *testing.T) {
+	m := newTestModel(nil)
+	m.loading = true
+
+	m = sendMsg(m, tablesLoadedMsg{err: errors.New("access denied")})
+
+	if m.loading {
+		t.Error("expected loading to be false")
+	}
+	if m.statusLine != "access denied" {
+		t.Errorf("unexpected status: %q", m.statusLine)
+	}
+}
+
+func TestCursorNavigation(t *testing.T) {
+	tables := []dynamodb.Table{
+		{Name: "alpha"},
+		{Name: "beta"},
+		{Name: "gamma"},
+	}
+	m := newTestModel(tables)
+
+	if m.cursor != 0 {
+		t.Fatalf("expected cursor at 0, got %d", m.cursor)
+	}
+
+	// Move down
+	m = sendKey(m, "j")
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1, got %d", m.cursor)
+	}
+
+	m = sendKey(m, "j")
+	if m.cursor != 2 {
+		t.Errorf("expected cursor at 2, got %d", m.cursor)
+	}
+
+	// Can't go past end
+	m = sendKey(m, "j")
+	if m.cursor != 2 {
+		t.Errorf("expected cursor to stay at 2, got %d", m.cursor)
+	}
+
+	// Move up
+	m = sendKey(m, "k")
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1, got %d", m.cursor)
+	}
+
+	// Can't go above 0
+	m = sendKey(m, "k")
+	m = sendKey(m, "k")
+	if m.cursor != 0 {
+		t.Errorf("expected cursor at 0, got %d", m.cursor)
+	}
+}
+
+func TestEnterTable(t *testing.T) {
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+	}
+	m := newTestModel(tables)
+
+	// Move to "orders" and enter
+	m = sendKey(m, "j")
+	m = sendSpecialKey(m, tea.KeyEnter)
+
+	if m.table != "orders" {
+		t.Errorf("expected table 'orders', got %q", m.table)
+	}
+	if m.cursor != 0 {
+		t.Errorf("expected cursor reset to 0, got %d", m.cursor)
+	}
+	if !m.loading {
+		t.Error("expected loading to be true after entering table")
+	}
+}
+
+func TestBackNavigation(t *testing.T) {
+	tables := []dynamodb.Table{
+		{Name: "users"},
+	}
+	m := newTestModel(tables)
+
+	// Enter a table
+	m = sendSpecialKey(m, tea.KeyEnter)
+	if m.table != "users" {
+		t.Fatalf("expected table 'users', got %q", m.table)
+	}
+
+	// Go back with esc
+	m = sendSpecialKey(m, tea.KeyEsc)
+	if m.table != "" {
+		t.Errorf("expected table to be empty after back, got %q", m.table)
+	}
+
+	// Enter again and go back with h
+	m = sendSpecialKey(m, tea.KeyEnter)
+	m = sendKey(m, "h")
+	if m.table != "" {
+		t.Errorf("expected table to be empty after h-back, got %q", m.table)
+	}
+
+	// Enter again and go back with backspace
+	m = sendSpecialKey(m, tea.KeyEnter)
+	m = sendSpecialKey(m, tea.KeyBackspace)
+	if m.table != "" {
+		t.Errorf("expected table to be empty after backspace-back, got %q", m.table)
+	}
+}
+
+func TestBackAtRootIsNoop(t *testing.T) {
+	m := newTestModel([]dynamodb.Table{{Name: "test"}})
+
+	// Back at root should do nothing
+	m = sendSpecialKey(m, tea.KeyEsc)
+	if m.table != "" {
+		t.Error("expected to stay at root")
+	}
+}
+
+func TestSearchMode(t *testing.T) {
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+		{Name: "user-activity"},
+	}
+	m := newTestModel(tables)
+
+	// Enter search mode
+	m = sendKey(m, "/")
+	if !m.searching {
+		t.Error("expected searching to be true")
+	}
+
+	// Exit search with escape
+	m = sendSpecialKey(m, tea.KeyEsc)
+	if m.searching {
+		t.Error("expected searching to be false after escape")
+	}
+}
+
+func TestFilteredTables(t *testing.T) {
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+		{Name: "user-activity"},
+	}
+	m := newTestModel(tables)
+
+	// No filter - should return all
+	filtered := m.filteredTables()
+	if len(filtered) != 3 {
+		t.Errorf("expected 3 tables, got %d", len(filtered))
+	}
+
+	// Set search value manually (simulating search input)
+	m.search.SetValue("user")
+	filtered = m.filteredTables()
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 filtered tables, got %d", len(filtered))
+	}
+}
+
+func TestFilteredItems(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.items = []dynamodb.Item{
+		{"id": "1", "name": "Alice"},
+		{"id": "2", "name": "Bob"},
+		{"id": "3", "name": "Charlie"},
+	}
+
+	// No filter
+	filtered := m.filteredItems()
+	if len(filtered) != 3 {
+		t.Errorf("expected 3 items, got %d", len(filtered))
+	}
+
+	// Filter by value
+	m.search.SetValue("alice")
+	filtered = m.filteredItems()
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 filtered item, got %d", len(filtered))
+	}
+}
+
+func TestItemsLoadedMsg(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.loading = true
+
+	items := []dynamodb.Item{
+		{"id": "1", "name": "Alice"},
+		{"id": "2", "name": "Bob"},
+	}
+	result := &dynamodb.ScanResult{
+		Items:        items,
+		ScannedCount: 2,
+	}
+	m = sendMsg(m, itemsLoadedMsg{result: result, tableName: "users"})
+
+	if m.loading {
+		t.Error("expected loading to be false")
+	}
+	if len(m.items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(m.items))
+	}
+	if m.statusLine != "Loaded 2 items" {
+		t.Errorf("unexpected status: %q", m.statusLine)
+	}
+}
+
+func TestItemsLoadedWithPagination(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.loading = true
+
+	result := &dynamodb.ScanResult{
+		Items:            []dynamodb.Item{{"id": "1"}},
+		LastEvaluatedKey: map[string]interface{}{"id": "1"},
+		ScannedCount:     1,
+	}
+	m = sendMsg(m, itemsLoadedMsg{result: result, tableName: "users"})
+
+	if m.lastEvaluatedKey == nil {
+		t.Error("expected lastEvaluatedKey to be set")
+	}
+	if m.statusLine != "Loaded 1 items (more available)" {
+		t.Errorf("unexpected status: %q", m.statusLine)
+	}
+}
+
+func TestItemsIgnoredWhenTableChanged(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "orders" // Changed to a different table
+
+	result := &dynamodb.ScanResult{
+		Items: []dynamodb.Item{{"id": "1"}},
+	}
+	m = sendMsg(m, itemsLoadedMsg{result: result, tableName: "users"})
+
+	// Items should not be set because table changed
+	if len(m.items) != 0 {
+		t.Errorf("expected 0 items (wrong table), got %d", len(m.items))
+	}
+}
+
+func TestMoreTablesLoaded(t *testing.T) {
+	tables := []dynamodb.Table{{Name: "first"}}
+	m := newTestModel(tables)
+
+	m = sendMsg(m, moreTablesLoadedMsg{
+		tables: []dynamodb.Table{{Name: "second"}},
+	})
+
+	if len(m.tables) != 2 {
+		t.Errorf("expected 2 tables, got %d", len(m.tables))
+	}
+}
+
+func TestMoreItemsLoaded(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.items = []dynamodb.Item{{"id": "1"}}
+
+	result := &dynamodb.ScanResult{
+		Items: []dynamodb.Item{{"id": "2"}},
+	}
+	m = sendMsg(m, moreItemsLoadedMsg{result: result})
+
+	if len(m.items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(m.items))
+	}
+}
+
+func TestExpandItemInItemsView(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.items = []dynamodb.Item{
+		{"id": "1", "name": "Alice"},
+	}
+	m.itemColumns = []string{"id", "name"}
+
+	// Press enter to expand
+	m = sendSpecialKey(m, tea.KeyEnter)
+	if m.expandedItem != 0 {
+		t.Errorf("expected expandedItem to be 0, got %d", m.expandedItem)
+	}
+
+	// Press esc to close
+	m = sendSpecialKey(m, tea.KeyEsc)
+	if m.expandedItem != -1 {
+		t.Errorf("expected expandedItem to be -1, got %d", m.expandedItem)
+	}
+}
+
+func TestExpandItemWithSpace(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.items = []dynamodb.Item{
+		{"id": "1", "name": "Alice"},
+	}
+	m.itemColumns = []string{"id", "name"}
+
+	// Press space to expand
+	m = sendKey(m, " ")
+	if m.expandedItem != 0 {
+		t.Errorf("expected expandedItem to be 0, got %d", m.expandedItem)
+	}
+}
+
+func TestGetARN(t *testing.T) {
+	// Table list view
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+	}
+	m := newTestModel(tables)
+	m.cursor = 1
+
+	arn := m.getARN()
+	if arn != "arn:aws:dynamodb:*:*:table/orders" {
+		t.Errorf("unexpected ARN: %q", arn)
+	}
+
+	// Items view
+	m.table = "users"
+	arn = m.getARN()
+	if arn != "arn:aws:dynamodb:*:*:table/users" {
+		t.Errorf("unexpected ARN: %q", arn)
+	}
+
+	// Empty table list
+	m2 := newTestModel(nil)
+	arn = m2.getARN()
+	if arn != "" {
+		t.Errorf("expected empty ARN, got %q", arn)
+	}
+}
+
+func TestWindowSizeMsg(t *testing.T) {
+	m := newTestModel(nil)
+	m = sendMsg(m, tea.WindowSizeMsg{Width: 200, Height: 50})
+
+	if m.width != 200 {
+		t.Errorf("expected width 200, got %d", m.width)
+	}
+	if m.height != 50 {
+		t.Errorf("expected height 50, got %d", m.height)
+	}
+}
+
+func TestTableDescriptionMsg(t *testing.T) {
+	tables := []dynamodb.Table{{Name: "users"}}
+	m := newTestModel(tables)
+
+	desc := &dynamodb.TableDescription{
+		Name:      "users",
+		Status:    "ACTIVE",
+		ItemCount: 100,
+	}
+	m = sendMsg(m, tableDescriptionMsg{desc: desc, tableName: "users"})
+
+	if m.description == nil {
+		t.Fatal("expected description to be set")
+	}
+	if m.description.Name != "users" {
+		t.Errorf("expected description name 'users', got %q", m.description.Name)
+	}
+}
+
+func TestTableDescriptionIgnoredForWrongTable(t *testing.T) {
+	tables := []dynamodb.Table{{Name: "users"}}
+	m := newTestModel(tables)
+
+	desc := &dynamodb.TableDescription{
+		Name:   "orders",
+		Status: "ACTIVE",
+	}
+	m = sendMsg(m, tableDescriptionMsg{desc: desc, tableName: "orders"})
+
+	// Description for wrong table should not be set
+	if m.description != nil {
+		t.Error("expected description to be nil for non-matching table")
+	}
+}
+
+func TestBuildColumns(t *testing.T) {
+	m := newTestModel(nil)
+	m.items = []dynamodb.Item{
+		{"id": "1", "name": "Alice", "age": "30"},
+		{"id": "2", "email": "bob@example.com"},
+	}
+	m.description = &dynamodb.TableDescription{
+		KeySchema: []dynamodb.KeySchema{
+			{AttributeName: "id", KeyType: "HASH"},
+		},
+	}
+
+	columns := m.buildColumns()
+
+	// "id" should be first (it's a key attribute)
+	if len(columns) == 0 {
+		t.Fatal("expected columns")
+	}
+	if columns[0] != "id" {
+		t.Errorf("expected first column to be 'id', got %q", columns[0])
+	}
+}
+
+func TestStatusHelp(t *testing.T) {
+	m := newTestModel([]dynamodb.Table{{Name: "test"}})
+
+	// Table list view
+	help := m.StatusHelp()
+	if help != "↑↓ move, / search, enter open, y copy ARN" {
+		t.Errorf("unexpected help: %q", help)
+	}
+
+	// Items view
+	m.table = "test"
+	help = m.StatusHelp()
+	if help != "↑↓ move, / search, enter expand, y copy ARN, esc/h back" {
+		t.Errorf("unexpected help: %q", help)
+	}
+
+	// Searching
+	m.searching = true
+	help = m.StatusHelp()
+	if help != "enter/esc close search" {
+		t.Errorf("unexpected help: %q", help)
+	}
+
+	// Expanded item
+	m.searching = false
+	m.expandedItem = 0
+	help = m.StatusHelp()
+	if help != "↑↓ scroll, pgup/pgdn page, esc close" {
+		t.Errorf("unexpected help: %q", help)
+	}
+}
+
+func TestViewRendersWithoutPanic(t *testing.T) {
+	// Table list view
+	tables := []dynamodb.Table{
+		{Name: "users"},
+		{Name: "orders"},
+	}
+	m := newTestModel(tables)
+
+	view := m.View()
+	if view == "" {
+		t.Error("expected non-empty view")
+	}
+
+	// Width 0 should show loading
+	m.width = 0
+	view = m.View()
+	if view != "Loading..." {
+		t.Errorf("expected 'Loading...', got %q", view)
+	}
+}
+
+func TestViewRendersItemsWithoutPanic(t *testing.T) {
+	m := newTestModel(nil)
+	m.table = "users"
+	m.items = []dynamodb.Item{
+		{"id": "1", "name": "Alice"},
+	}
+	m.itemColumns = []string{"id", "name"}
+
+	view := m.View()
+	if view == "" {
+		t.Error("expected non-empty view")
+	}
+}
+
+func TestClampCursor(t *testing.T) {
+	m := newTestModel([]dynamodb.Table{{Name: "a"}, {Name: "b"}})
+	m.cursor = 10 // Way past the end
+
+	m.clampCursor()
+
+	if m.cursor != 1 {
+		t.Errorf("expected cursor clamped to 1, got %d", m.cursor)
+	}
+}
+
+func TestClampCursorEmpty(t *testing.T) {
+	m := newTestModel(nil) // No tables
+	m.cursor = 5
+
+	m.clampCursor()
+
+	if m.cursor != 0 {
+		t.Errorf("expected cursor clamped to 0, got %d", m.cursor)
+	}
+}

--- a/internal/ui/dynamodb/views.go
+++ b/internal/ui/dynamodb/views.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sachamama/sacha/internal/dynamodb"
 )
@@ -29,6 +30,11 @@ var (
 
 	labelStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("33"))
+
+	popupStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("63")).
+			Padding(1, 2)
 )
 
 func lipglossJoinHorizontal(left, right string) string {
@@ -267,4 +273,50 @@ func formatBytes(bytes int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func (m Model) renderExpandedItem(item dynamodb.Item) string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, titleStyle.Render("Item Details"))
+	fmt.Fprintf(b, "%s %s\n", dimText.Render("Table:"), m.table)
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, m.expandedView.View())
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("↑↓/j/k scroll, pgup/pgdn page, esc close"))
+
+	maxWidth := m.width - 10
+	if maxWidth > 100 {
+		maxWidth = 100
+	}
+	return popupStyle.Width(maxWidth).Render(b.String())
+}
+
+// initExpandedItemView creates a viewport for displaying an expanded DynamoDB item.
+func initExpandedItemView(item dynamodb.Item, columns []string, width, height int) viewport.Model {
+	maxWidth := width - 10
+	if maxWidth > 100 {
+		maxWidth = 100
+	}
+	viewportHeight := height - 14
+	if viewportHeight < 5 {
+		viewportHeight = 5
+	}
+
+	// Build content: show all attributes with full values
+	var b strings.Builder
+	keys := columns
+	if len(keys) == 0 {
+		keys = dynamodb.ItemKeys(item)
+	}
+	for _, k := range keys {
+		v, ok := item[k]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "%s: %s\n", k, v)
+	}
+
+	vp := viewport.New(maxWidth-4, viewportHeight)
+	vp.SetContent(b.String())
+	return vp
 }


### PR DESCRIPTION
- Add expanded item popup (enter/space) with scrollable viewport for full attribute details
- Add copy ARN shortcut (y) for tables and items view
- Add h key as back navigation alias (consistent with S3 service)
- Add UI-level tests for DynamoDB model (navigation, search, messages, expansion)
- Add popupStyle and renderExpandedItem/initExpandedItemView for popup overlay
- Document DynamoDB keyboard shortcuts in CLAUDE.md

https://claude.ai/code/session_01P463wnX2pYibRWP67nd6ab