### PR TITLE
fix: update golangci-lint-action to v8 for golangci-lint v2 config compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.8
 
   security:
     name: Security


### PR DESCRIPTION
The CI lint job was failing because golangci-lint-action@v6 installed
golangci-lint v1.x which doesn't support the v2 config format used in
.golangci.yml. Updated to action@v8 with explicit v2.8 version pin.

https://claude.ai/code/session_01NfF4GcTvQ1tYu1ECirVf4C