### PR TITLE
fix: add scrollable viewport to DynamoDB detail panel

### DIFF
--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -45,6 +45,9 @@ type Model struct {
 	expandedItem int            // index of expanded item, -1 if none
 	expandedView viewport.Model // viewport for expanded item
 
+	// Detail panel (right side) viewport for scrollable details
+	detailViewport viewport.Model
+
 	// UI
 	width      int
 	height     int
@@ -78,6 +81,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.updateDetailViewport()
 
 	case tablesLoadedMsg:
 		m.loading = false
@@ -107,6 +111,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.currentTableName() == msg.tableName || m.table == msg.tableName {
 			m.description = msg.desc
+			m.updateDetailViewport()
 		}
 		return m, nil
 
@@ -129,6 +134,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusLine = fmt.Sprintf("Loaded %d items", len(m.items))
 		}
+		m.updateDetailViewport()
 		return m, nil
 
 	case moreItemsLoadedMsg:
@@ -145,6 +151,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusLine = fmt.Sprintf("Loaded %d items", len(m.items))
 		}
+		m.updateDetailViewport()
 		return m, nil
 
 	case tea.KeyMsg:
@@ -178,11 +185,13 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter, tea.KeyEscape:
 			m.searching = false
 			m.clampCursor()
+			m.updateDetailViewport()
 			return m, nil
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)
 		m.clampCursor()
+		m.updateDetailViewport()
 		return m, cmd
 	}
 
@@ -191,6 +200,10 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor > 0 {
 			m.cursor--
 			m.ensureCursorVisible()
+			if m.table == "" {
+				m.description = nil
+			}
+			m.updateDetailViewport()
 			return m, m.onCursorMove()
 		}
 	case "down", "j":
@@ -198,6 +211,10 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor < maxIdx {
 			m.cursor++
 			m.ensureCursorVisible()
+			if m.table == "" {
+				m.description = nil
+			}
+			m.updateDetailViewport()
 			cmd := m.onCursorMove()
 			// Lazy load more when near the end
 			if m.table == "" && m.tableToken != nil && !m.loadingMore {
@@ -239,6 +256,10 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			_ = clipboard.WriteAll(arn)
 			m.statusLine = "Copied: " + arn
 		}
+	case "pgup":
+		m.detailViewport.HalfPageUp()
+	case "pgdn":
+		m.detailViewport.HalfPageDown()
 	}
 
 	return m, nil
@@ -367,6 +388,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		m.items = nil
 		m.lastEvaluatedKey = nil
 		m.itemColumns = nil
+		m.updateDetailViewport()
 		return m, tea.Batch(m.scanItemsCmd(), m.fetchDescriptionForTableCmd(m.table))
 	}
 	return m, nil
@@ -386,6 +408,7 @@ func (m Model) handleBack() (tea.Model, tea.Cmd) {
 	m.description = nil
 	m.search.SetValue("")
 	m.clampCursor()
+	m.updateDetailViewport()
 	return m, m.fetchDescriptionCmd()
 }
 
@@ -518,7 +541,7 @@ func (m Model) StatusHelp() string {
 		return "enter/esc close search"
 	}
 	if m.table == "" {
-		return "↑↓ move, / search, enter open, y copy ARN"
+		return "↑↓ move, / search, enter open, pgup/pgdn details, y copy ARN"
 	}
-	return "↑↓ move, / search, enter expand, y copy ARN, esc/h back"
+	return "↑↓ move, / search, enter expand, pgup/pgdn details, y copy ARN, esc/h back"
 }

--- a/internal/ui/dynamodb/model_test.go
+++ b/internal/ui/dynamodb/model_test.go
@@ -14,6 +14,7 @@ func newTestModel(tables []dynamodb.Table) Model {
 	m.loading = false
 	m.width = 120
 	m.height = 40
+	m.updateDetailViewport()
 	return m
 }
 
@@ -484,14 +485,14 @@ func TestStatusHelp(t *testing.T) {
 
 	// Table list view
 	help := m.StatusHelp()
-	if help != "↑↓ move, / search, enter open, y copy ARN" {
+	if help != "↑↓ move, / search, enter open, pgup/pgdn details, y copy ARN" {
 		t.Errorf("unexpected help: %q", help)
 	}
 
 	// Items view
 	m.table = "test"
 	help = m.StatusHelp()
-	if help != "↑↓ move, / search, enter expand, y copy ARN, esc/h back" {
+	if help != "↑↓ move, / search, enter expand, pgup/pgdn details, y copy ARN, esc/h back" {
 		t.Errorf("unexpected help: %q", help)
 	}
 

--- a/internal/ui/dynamodb/views.go
+++ b/internal/ui/dynamodb/views.go
@@ -174,83 +174,126 @@ func (m Model) renderRight() string {
 	b := &strings.Builder{}
 
 	if m.table == "" {
-		return m.renderTableDetails(b)
+		fmt.Fprintln(b, titleStyle.Render("Table Details"))
+	} else {
+		fmt.Fprintln(b, titleStyle.Render("Item Details"))
 	}
-	return m.renderItemDetails(b)
+
+	fmt.Fprint(b, m.detailViewport.View())
+
+	// Show scroll hint when content overflows
+	if m.detailViewport.TotalLineCount() > m.detailViewport.VisibleLineCount() {
+		pct := int(m.detailViewport.ScrollPercent() * 100)
+		fmt.Fprintf(b, "\n%s", dimText.Render(fmt.Sprintf("  ↕ %d%% (pgup/pgdn)", pct)))
+	}
+
+	return b.String()
 }
 
-func (m Model) renderTableDetails(b *strings.Builder) string {
-	fmt.Fprintln(b, titleStyle.Render("Table Details"))
+func (m Model) buildTableDetailsContent() string {
+	var b strings.Builder
 
 	tables := m.filteredTables()
 	if len(tables) == 0 || m.cursor >= len(tables) {
-		fmt.Fprintln(b, dimText.Render("No table selected"))
+		fmt.Fprintln(&b, dimText.Render("No table selected"))
 		return b.String()
 	}
 
 	if m.description == nil {
-		fmt.Fprintln(b, dimText.Render("Loading details..."))
+		fmt.Fprintln(&b, dimText.Render("Loading details..."))
 		return b.String()
 	}
 
 	d := m.description
-	fmt.Fprintln(b)
-	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), d.Name)
-	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Status:"), d.Status)
-	fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("Items:"), d.ItemCount)
-	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Size:"), formatBytes(d.TableSizeBytes))
-	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Created:"), d.CreationDateTime.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Billing:"), d.BillingMode)
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render("Name:"), d.Name)
+	fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render("Status:"), d.Status)
+	fmt.Fprintf(&b, "%s  %d\n", labelStyle.Render("Items:"), d.ItemCount)
+	fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render("Size:"), formatBytes(d.TableSizeBytes))
+	fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render("Created:"), d.CreationDateTime.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render("Billing:"), d.BillingMode)
 
 	if d.BillingMode == "PROVISIONED" {
-		fmt.Fprintf(b, "%s  %d RCU / %d WCU\n", labelStyle.Render("Capacity:"), d.ReadCapacity, d.WriteCapacity)
+		fmt.Fprintf(&b, "%s  %d RCU / %d WCU\n", labelStyle.Render("Capacity:"), d.ReadCapacity, d.WriteCapacity)
 	}
 
-	fmt.Fprintln(b)
-	fmt.Fprintln(b, titleStyle.Render("Key Schema"))
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, titleStyle.Render("Key Schema"))
 	for _, ks := range d.KeySchema {
 		attrType := attributeType(d.AttributeDefinitions, ks.AttributeName)
-		fmt.Fprintf(b, "  %s (%s, %s)\n", ks.AttributeName, ks.KeyType, attrType)
+		fmt.Fprintf(&b, "  %s (%s, %s)\n", ks.AttributeName, ks.KeyType, attrType)
 	}
 
 	if len(d.GlobalSecondaryIndexes) > 0 {
-		fmt.Fprintln(b)
-		fmt.Fprintln(b, titleStyle.Render("Global Secondary Indexes"))
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, titleStyle.Render("Global Secondary Indexes"))
 		for _, gsi := range d.GlobalSecondaryIndexes {
-			fmt.Fprintf(b, "  %s [%s]\n", gsi.Name, gsi.Status)
+			fmt.Fprintf(&b, "  %s [%s]\n", gsi.Name, gsi.Status)
 			for _, ks := range gsi.KeySchema {
 				attrType := attributeType(d.AttributeDefinitions, ks.AttributeName)
-				fmt.Fprintf(b, "    %s (%s, %s)\n", ks.AttributeName, ks.KeyType, attrType)
+				fmt.Fprintf(&b, "    %s (%s, %s)\n", ks.AttributeName, ks.KeyType, attrType)
 			}
 		}
 	}
 
-	fmt.Fprintln(b)
-	fmt.Fprintln(b, dimText.Render("ARN"))
-	fmt.Fprintf(b, "arn:aws:dynamodb:*:*:table/%s\n", d.Name)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, dimText.Render("ARN"))
+	fmt.Fprintf(&b, "arn:aws:dynamodb:*:*:table/%s\n", d.Name)
 
 	return b.String()
 }
 
-func (m Model) renderItemDetails(b *strings.Builder) string {
-	fmt.Fprintln(b, titleStyle.Render("Item Details"))
+func (m Model) buildItemDetailsContent() string {
+	var b strings.Builder
 
 	items := m.filteredItems()
 	if len(items) == 0 || m.cursor >= len(items) {
-		fmt.Fprintln(b, dimText.Render("No item selected"))
+		fmt.Fprintln(&b, dimText.Render("No item selected"))
 		return b.String()
 	}
 
 	item := items[m.cursor]
-	fmt.Fprintln(b)
+	fmt.Fprintln(&b)
 
 	keys := dynamodb.ItemKeys(item)
 	for _, k := range keys {
 		v := item[k]
-		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render(k+":"), v)
+		fmt.Fprintf(&b, "%s  %s\n", labelStyle.Render(k+":"), v)
 	}
 
 	return b.String()
+}
+
+// detailViewportSize returns the width and height for the detail panel viewport.
+func (m Model) detailViewportSize() (int, int) {
+	rightWidth := m.width - m.width/2
+	// panelStyle: border(2h+2v) + padding(0v+2h) => content = width-4 h, height-2 v
+	contentWidth := rightWidth - 6
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+	// bodyHeight is total panel height; subtract border(2), title(1), scroll hint(1)
+	vpHeight := m.bodyHeight() - 4
+	if vpHeight < 3 {
+		vpHeight = 3
+	}
+	return contentWidth, vpHeight
+}
+
+// updateDetailViewport rebuilds the detail panel viewport content and resets scroll.
+func (m *Model) updateDetailViewport() {
+	w, h := m.detailViewportSize()
+	m.detailViewport.Width = w
+	m.detailViewport.Height = h
+
+	var content string
+	if m.table == "" {
+		content = m.buildTableDetailsContent()
+	} else {
+		content = m.buildItemDetailsContent()
+	}
+	m.detailViewport.SetContent(content)
+	m.detailViewport.GotoTop()
 }
 
 func attributeType(defs []dynamodb.AttributeDefinition, name string) string {


### PR DESCRIPTION
The right-side detail panel for table details and item details would
overflow and clip content when tables had many GSIs or items had many
attributes. Replace the static rendering with a viewport-based approach
that allows scrolling via pgup/pgdn keys.

https://claude.ai/code/session_014FgzRbM2c4CMBUSYh7LEPB