### PR TITLE
fix(ui): refresh details panel after closing search

### DIFF
--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -186,7 +186,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.searching = false
 			m.clampCursor()
 			m.updateDetailViewport()
-			return m, nil
+			return m, m.onCursorMove()
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)

--- a/internal/ui/lambda/model.go
+++ b/internal/ui/lambda/model.go
@@ -129,7 +129,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter, tea.KeyEscape:
 			m.searching = false
 			m.clampCursor()
-			return m, nil
+			return m, m.onCursorMove()
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)

--- a/internal/ui/s3/model.go
+++ b/internal/ui/s3/model.go
@@ -245,7 +245,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter, tea.KeyEscape:
 			m.searching = false
 			m.clampCursor()
-			return m, nil
+			return m, m.onCursorMove()
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)


### PR DESCRIPTION
## Summary
- When closing search with Enter or Escape, call `onCursorMove()` to fetch fresh details for the now-current item
- Previously the details panel showed stale data from the pre-search selection
- Affects Lambda, DynamoDB, and S3 views

## Changes
- `internal/ui/lambda/model.go`: Change `return m, nil` to `return m, m.onCursorMove()` on search close
- `internal/ui/dynamodb/model.go`: Same fix
- `internal/ui/s3/model.go`: Same fix

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `golangci-lint` passes
- [ ] Manual: In any service, use `/` to filter, close with Esc, verify details panel updates

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)