### PR TITLE
feat(ui): show loading indicator during lazy-load pagination

### DIFF
--- a/internal/ui/dynamodb/views.go
+++ b/internal/ui/dynamodb/views.go
@@ -109,7 +109,11 @@ func (m Model) renderTableList(b *strings.Builder, visibleHeight int) {
 	}
 
 	if endIdx < len(tables) {
-		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
 	}
 }
 
@@ -137,7 +141,11 @@ func (m Model) renderItemList(b *strings.Builder, visibleHeight int) {
 	}
 
 	if endIdx < len(items) {
-		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
 	}
 }
 

--- a/internal/ui/lambda/views.go
+++ b/internal/ui/lambda/views.go
@@ -110,7 +110,11 @@ func (m Model) renderFunctionList(b *strings.Builder, visibleHeight int) {
 	}
 
 	if endIdx < len(functions) {
-		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
 	}
 }
 

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -100,7 +100,11 @@ func (m Model) renderGroups() string {
 	}
 
 	if endIdx < len(groups) {
-		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
 	}
 
 	fmt.Fprintf(b, "\n%s\n", dimText.Render(fmt.Sprintf("Selected: %d | Total: %d", m.selectedCount(), len(m.logGroups))))

--- a/internal/ui/s3/views.go
+++ b/internal/ui/s3/views.go
@@ -175,7 +175,11 @@ func (m Model) renderObjectList(b *strings.Builder, visibleHeight int) {
 	}
 
 	if endIdx < len(objects) {
-		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Show a loading indicator ("loading more...") at the bottom of list views when lazy-loading additional pages from AWS APIs
- Replaces the static "more below" text with dynamic feedback during pagination in CloudWatch Logs, Lambda, DynamoDB (tables and items), and S3 (objects) views
- S3 bucket list is unchanged since buckets don't use lazy-load pagination

## Test plan
- [ ] Navigate to a CloudWatch Logs view with many log groups, scroll near the bottom to trigger lazy-load, verify "loading more..." appears
- [ ] Repeat for Lambda functions list
- [ ] Repeat for DynamoDB tables list and items list
- [ ] Repeat for S3 objects list
- [ ] Verify S3 buckets list still shows "more below" (no loading indicator since buckets don't paginate)
- [ ] Verify indicator disappears and reverts to "more below" once loading completes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)