### PR TITLE
feat(ui): show global shortcuts in footer

### DIFF
--- a/internal/ui/app/model.go
+++ b/internal/ui/app/model.go
@@ -114,10 +114,13 @@ func (m Model) View() string {
 	if status == "" {
 		status = getStatusHelp(m.service)
 	}
-	if status == "" {
-		status = "r region, s service, ctrl+c quit"
+	globalShortcuts := "r region  s service  ctrl+c quit"
+	var footer string
+	if status != "" {
+		footer = fmt.Sprintf("%s │ %s │ %s", status, globalShortcuts, version.Short())
+	} else {
+		footer = fmt.Sprintf("%s │ %s", globalShortcuts, version.Short())
 	}
-	footer := fmt.Sprintf("%s │ %s", status, version.Short())
 	return fmt.Sprintf("%s\n%s\n%s", header, body, footer)
 }
 


### PR DESCRIPTION
## Summary
- Always display global shortcuts (region, service, quit) in the footer alongside service-specific help text
- When a selector popup is active (region or service), global shortcuts are hidden since those views have their own instructions
- When no service help is available, only the global shortcuts and version are shown

Closes #31

## Test plan
- [ ] Launch the app and verify the footer shows service help + global shortcuts + version
- [ ] Press r to open region selector and verify global shortcuts disappear from footer
- [ ] Press s to open service selector and verify global shortcuts disappear from footer
- [ ] Switch services and verify the footer updates with service-specific help while keeping global shortcuts
- [ ] Verify the footer renders correctly on narrow terminal widths

Generated with [Claude Code](https://claude.com/claude-code)