### PR TITLE
feat(ui): unify visual styling across all service views

### DIFF
--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -58,19 +58,21 @@ var (
 
 func (m Model) renderGroups() string {
 	b := &strings.Builder{}
-	header := titleStyle.Render("Log Groups")
+	fmt.Fprintln(b, titleStyle.Render("Log Groups"))
+
 	if m.loading {
-		header += " " + dimText.Render("(loading...)")
+		fmt.Fprintln(b, dimText.Render("Loading..."))
+		return b.String()
 	}
-	fmt.Fprintln(b, header)
+
 	if m.searching {
 		fmt.Fprintln(b, m.search.View())
 	} else {
-		fmt.Fprintln(b, dimText.Render("/ search, c create"))
+		fmt.Fprintln(b, dimText.Render("Press / to filter"))
 	}
 	groups := m.filteredGroups()
 	if len(groups) == 0 {
-		fmt.Fprintln(b, "no log groups")
+		fmt.Fprintln(b, dimText.Render("No log groups found"))
 		return b.String()
 	}
 

--- a/internal/ui/s3/views.go
+++ b/internal/ui/s3/views.go
@@ -27,6 +27,9 @@ var (
 	dimText = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("241"))
 
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("33"))
+
 	statusStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("44"))
 
@@ -195,9 +198,9 @@ func (m Model) renderRight() string {
 			region = "loading..."
 		}
 		fmt.Fprintln(b)
-		fmt.Fprintf(b, "Name:     %s\n", bucket.Name)
-		fmt.Fprintf(b, "Created:  %s\n", bucket.CreationDate.Format("2006-01-02 15:04:05"))
-		fmt.Fprintf(b, "Region:   %s\n", region)
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), bucket.Name)
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Created:"), bucket.CreationDate.Format("2006-01-02 15:04:05"))
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Region:"), region)
 		fmt.Fprintln(b)
 		fmt.Fprintln(b, dimText.Render("URIs"))
 		fmt.Fprintf(b, "S3:       s3://%s/\n", bucket.Name)
@@ -221,7 +224,7 @@ func (m Model) renderRight() string {
 		obj := objects[m.cursor]
 		if obj.IsPrefix {
 			fmt.Fprintln(b)
-			fmt.Fprintf(b, "Folder:   %s\n", obj.Name)
+			fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Folder:"), obj.Name)
 			fmt.Fprintln(b)
 			fmt.Fprintln(b, dimText.Render("URIs"))
 			fmt.Fprintf(b, "S3:       s3://%s/%s\n", m.bucket, obj.Key)
@@ -236,12 +239,12 @@ func (m Model) renderRight() string {
 	}
 
 	fmt.Fprintln(b)
-	fmt.Fprintf(b, "Key:           %s\n", m.details.Key)
-	fmt.Fprintf(b, "Size:          %s (%d bytes)\n", formatSize(m.details.Size), m.details.Size)
-	fmt.Fprintf(b, "Last Modified: %s\n", m.details.LastModified.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(b, "Storage Class: %s\n", m.details.StorageClass)
-	fmt.Fprintf(b, "Content-Type:  %s\n", m.details.ContentType)
-	fmt.Fprintf(b, "ETag:          %s\n", m.details.ETag)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Key:"), m.details.Key)
+	fmt.Fprintf(b, "%s  %s (%d bytes)\n", labelStyle.Render("Size:"), formatSize(m.details.Size), m.details.Size)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Modified:"), m.details.LastModified.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Storage:"), m.details.StorageClass)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Type:"), m.details.ContentType)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("ETag:"), m.details.ETag)
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, dimText.Render("URIs"))
 	fmt.Fprintf(b, "S3:            s3://%s/%s\n", m.bucket, m.details.Key)


### PR DESCRIPTION
## Summary
- Standardize Logs empty state to use `dimText.Render("No log groups found")` (was plain `"no log groups"`)
- Change Logs search hint to `"Press / to filter"` matching Lambda, DynamoDB, S3
- Change Logs loading to separate `"Loading..."` line matching other services
- Add `labelStyle` to S3 detail panel labels matching Lambda and DynamoDB

## Changes
- `internal/ui/logs/views.go` — Uniform empty state, search hint, loading display
- `internal/ui/s3/views.go` — Add `labelStyle`, apply to bucket and object detail fields

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `golangci-lint` passes
- [ ] Manual: Switch between services and verify uniform appearance

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)