### PR TITLE
feat(ui): show active filter indicator and auto-load pages on filter

### DIFF
--- a/internal/ui/app/model.go
+++ b/internal/ui/app/model.go
@@ -77,15 +77,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c":
 			return m, tea.Quit
 		case "q":
-			if !isTailing(m.service) {
+			if !isSearching(m.service) && !isTailing(m.service) {
 				return m, tea.Quit
 			}
 		case "r":
-			m.regionSelector.open(awsRegions, m.runtime.Region)
-			return m, m.regionSelector.input.Focus()
+			if !isSearching(m.service) {
+				m.regionSelector.open(awsRegions, m.runtime.Region)
+				return m, m.regionSelector.input.Focus()
+			}
 		case "s":
-			m.serviceSelector.open(serviceNames(m.services), m.runtime.Service)
-			return m, m.serviceSelector.input.Focus()
+			if !isSearching(m.service) {
+				m.serviceSelector.open(serviceNames(m.services), m.runtime.Service)
+				return m, m.serviceSelector.input.Focus()
+			}
 		}
 	}
 
@@ -221,6 +225,17 @@ type tailAware interface {
 func isTailing(m tea.Model) bool {
 	if t, ok := m.(tailAware); ok {
 		return t.Tailing()
+	}
+	return false
+}
+
+type searchAware interface {
+	Searching() bool
+}
+
+func isSearching(m tea.Model) bool {
+	if s, ok := m.(searchAware); ok {
+		return s.Searching()
 	}
 	return false
 }

--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -103,7 +103,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.tables = append(m.tables, msg.tables...)
 		m.tableToken = msg.nextToken
 		m.statusLine = fmt.Sprintf("Loaded %d tables", len(m.tables))
-		return m, nil
+		return m, m.loadMoreIfNeeded()
 
 	case tableDescriptionMsg:
 		if msg.err != nil {
@@ -152,7 +152,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusLine = fmt.Sprintf("Loaded %d items", len(m.items))
 		}
 		m.updateDetailViewport()
-		return m, nil
+		return m, m.loadMoreIfNeeded()
 
 	case tea.KeyMsg:
 		return m.handleKeyMsg(msg)
@@ -186,7 +186,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.searching = false
 			m.clampCursor()
 			m.updateDetailViewport()
-			return m, m.onCursorMove()
+			return m, tea.Batch(m.onCursorMove(), m.loadMoreIfNeeded())
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)
@@ -473,6 +473,37 @@ func (m Model) buildColumns() []string {
 	return append(keyColumns, otherColumns...)
 }
 
+// loadMoreIfNeeded loads the next page if a filter is active and the filtered
+// results don't fill the visible list height.
+func (m *Model) loadMoreIfNeeded() tea.Cmd {
+	if m.search.Value() == "" {
+		return nil
+	}
+	if m.loadingMore {
+		return nil
+	}
+	if m.table == "" {
+		// Table list pagination
+		if m.tableToken == nil {
+			return nil
+		}
+		if len(m.filteredTables()) >= m.listHeight() {
+			return nil
+		}
+		m.loadingMore = true
+		return m.loadMoreTablesCmd()
+	}
+	// Items pagination
+	if m.lastEvaluatedKey == nil {
+		return nil
+	}
+	if len(m.filteredItems()) >= m.listHeight() {
+		return nil
+	}
+	m.loadingMore = true
+	return m.loadMoreItemsCmd()
+}
+
 // Commands
 
 func (m Model) loadTablesCmd() tea.Cmd {
@@ -530,6 +561,11 @@ func (m Model) loadMoreItemsCmd() tea.Cmd {
 		result, err := m.client.Scan(ctx, tableName, startKey, scanPageSize)
 		return moreItemsLoadedMsg{result: result, err: err}
 	}
+}
+
+// Searching reports whether the model has an active text input.
+func (m Model) Searching() bool {
+	return m.searching
 }
 
 // StatusHelp returns context-aware help text for the status bar.

--- a/internal/ui/dynamodb/views.go
+++ b/internal/ui/dynamodb/views.go
@@ -58,6 +58,8 @@ func (m Model) renderLeft() string {
 	// Search input
 	if m.searching {
 		fmt.Fprintln(b, m.search.View())
+	} else if m.search.Value() != "" {
+		fmt.Fprintln(b, statusStyle.Render(fmt.Sprintf("Filter: %s", m.search.Value())))
 	} else {
 		fmt.Fprintln(b, dimText.Render("Press / to filter"))
 	}

--- a/internal/ui/lambda/model.go
+++ b/internal/ui/lambda/model.go
@@ -87,7 +87,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.functions = append(m.functions, msg.functions...)
 		m.nextToken = msg.nextToken
 		m.statusLine = fmt.Sprintf("Loaded %d functions", len(m.functions))
-		return m, nil
+		return m, m.loadMoreIfNeeded()
 
 	case functionDetailsMsg:
 		if msg.err != nil {
@@ -129,7 +129,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter, tea.KeyEscape:
 			m.searching = false
 			m.clampCursor()
-			return m, m.onCursorMove()
+			return m, tea.Batch(m.onCursorMove(), m.loadMoreIfNeeded())
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)
@@ -288,6 +288,22 @@ func (m Model) filteredFunctions() []lambda.Function {
 	return out
 }
 
+// loadMoreIfNeeded loads the next page if a filter is active and the filtered
+// results don't fill the visible list height.
+func (m *Model) loadMoreIfNeeded() tea.Cmd {
+	if m.search.Value() == "" {
+		return nil
+	}
+	if m.nextToken == nil || m.loadingMore {
+		return nil
+	}
+	if len(m.filteredFunctions()) >= m.listHeight() {
+		return nil
+	}
+	m.loadingMore = true
+	return m.loadMoreFunctionsCmd()
+}
+
 // Commands
 
 func (m Model) loadFunctionsCmd() tea.Cmd {
@@ -317,6 +333,11 @@ func (m Model) fetchDetailsCmd() tea.Cmd {
 		details, err := m.client.GetFunction(ctx, name)
 		return functionDetailsMsg{details: details, functionName: name, err: err}
 	}
+}
+
+// Searching reports whether the model has an active text input.
+func (m Model) Searching() bool {
+	return m.searching
 }
 
 // StatusHelp returns context-aware help text for the status bar.

--- a/internal/ui/lambda/views.go
+++ b/internal/ui/lambda/views.go
@@ -51,6 +51,8 @@ func (m Model) renderLeft() string {
 	// Search input
 	if m.searching {
 		fmt.Fprintln(b, m.search.View())
+	} else if m.search.Value() != "" {
+		fmt.Fprintln(b, statusStyle.Render(fmt.Sprintf("Filter: %s", m.search.Value())))
 	} else {
 		fmt.Fprintln(b, dimText.Render("Press / to filter"))
 	}

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -145,6 +145,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusLine = fmt.Sprintf("Loaded %d log groups", len(m.logGroups))
 		}
+		return m, m.loadMoreIfNeeded()
 	case logGroupCreatedMsg:
 		m.creating = false
 		if msg.err != nil {
@@ -179,7 +180,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.Type {
 			case tea.KeyEnter, tea.KeyEscape:
 				m.searching = false
-				return m, nil
+				return m, m.loadMoreIfNeeded()
 			}
 			var cmd tea.Cmd
 			m.search, cmd = m.search.Update(msg)
@@ -252,6 +253,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.eventCursor > 0 {
 					m.eventCursor--
 					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.ensureEventCursorVisible()
 				}
 			} else {
 				if m.cursor > 0 {
@@ -264,6 +266,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.eventCursor < len(m.events)-1 {
 					m.eventCursor++
 					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.ensureEventCursorVisible()
 				}
 			} else {
 				if m.cursor < len(m.filteredGroups())-1 {
@@ -343,6 +346,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.setViewportSize(m.bodyHeight())
 				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.ensureEventCursorVisible()
 			}
 		case "q", "esc":
 			if m.tailing {
@@ -355,6 +359,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.tailing {
 				m.jsonView = !m.jsonView
 				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.ensureEventCursorVisible()
 				return m, nil
 			}
 		case "x":
@@ -379,16 +384,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if len(msg.events) > 0 {
+			wasAtEnd := len(m.events) == 0 || m.eventCursor >= len(m.events)-1
 			m.tailStart = msg.nextStart
 			m.events = append(m.events, msg.events...)
 			if len(m.events) > 1000 {
-				m.events = m.events[len(m.events)-1000:]
+				trimmed := len(m.events) - 1000
+				m.events = m.events[trimmed:]
+				if !wasAtEnd {
+					m.eventCursor -= trimmed
+					if m.eventCursor < 0 {
+						m.eventCursor = 0
+					}
+				}
 			}
-			// Keep cursor in bounds
-			if m.eventCursor >= len(m.events) {
+			// Auto-scroll to latest events when cursor was at the end
+			if wasAtEnd {
+				m.eventCursor = len(m.events) - 1
+			} else if m.eventCursor >= len(m.events) {
 				m.eventCursor = len(m.events) - 1
 			}
 			m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+			m.ensureEventCursorVisible()
 		}
 		if m.tailing {
 			return m, tea.Tick(m.pollInterval, func(time.Time) tea.Msg { return pollTailMsg{} })
@@ -471,6 +487,25 @@ func (m Model) loadMoreLogGroupsCmd() tea.Cmd {
 	}
 }
 
+// loadMoreIfNeeded loads the next page if a filter is active and the filtered
+// results don't fill the visible list height.
+func (m *Model) loadMoreIfNeeded() tea.Cmd {
+	if m.tailing {
+		return nil
+	}
+	if m.search.Value() == "" {
+		return nil
+	}
+	if m.nextGroupToken == nil || m.loadingMore {
+		return nil
+	}
+	if len(m.filteredGroups()) >= m.listHeight() {
+		return nil
+	}
+	m.loadingMore = true
+	return m.loadMoreLogGroupsCmd()
+}
+
 func (m Model) pollTailCmd() tea.Cmd {
 	groups := m.selectedGroups()
 	start := m.tailStart
@@ -549,6 +584,11 @@ func (m Model) selectedCount() int {
 // Tailing reports whether the model is actively tailing logs.
 func (m Model) Tailing() bool {
 	return m.tailing
+}
+
+// Searching reports whether the model has an active text input.
+func (m Model) Searching() bool {
+	return m.searching || m.creating
 }
 
 // StatusHelp returns context-aware help text for the status bar.
@@ -648,5 +688,37 @@ func (m *Model) ensureCursorVisible() {
 
 	if m.listOffset < 0 {
 		m.listOffset = 0
+	}
+}
+
+// eventContentOffset returns the number of header lines rendered before event
+// rows in the viewport content. Table view prepends a blank line and a header
+// row; plain view starts immediately with event rows.
+func (m *Model) eventContentOffset() int {
+	if !m.jsonView {
+		return 0
+	}
+	for i, e := range m.events {
+		if i > 10 {
+			break
+		}
+		if parseJSONLog(e.Message) != nil {
+			return 2 // blank line + header row in table view
+		}
+	}
+	return 0
+}
+
+// ensureEventCursorVisible adjusts the viewport's YOffset so the line
+// corresponding to eventCursor is within the visible area.
+func (m *Model) ensureEventCursorVisible() {
+	if len(m.events) == 0 || m.view.Height <= 0 {
+		return
+	}
+	cursorLine := m.eventCursor + m.eventContentOffset()
+	if cursorLine < m.view.YOffset {
+		m.view.SetYOffset(cursorLine)
+	} else if cursorLine >= m.view.YOffset+m.view.Height {
+		m.view.SetYOffset(cursorLine - m.view.Height + 1)
 	}
 }

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -67,6 +67,8 @@ func (m Model) renderGroups() string {
 
 	if m.searching {
 		fmt.Fprintln(b, m.search.View())
+	} else if m.search.Value() != "" {
+		fmt.Fprintln(b, statusStyle.Render(fmt.Sprintf("Filter: %s", m.search.Value())))
 	} else {
 		fmt.Fprintln(b, dimText.Render("Press / to filter"))
 	}

--- a/internal/ui/s3/model.go
+++ b/internal/ui/s3/model.go
@@ -166,7 +166,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusLine = fmt.Sprintf("Loaded %d items", len(m.objects))
 		}
-		return m, nil
+		return m, m.loadMoreIfNeeded()
 
 	case allObjectsLoadedMsg:
 		m.loadingMore = false
@@ -245,7 +245,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter, tea.KeyEscape:
 			m.searching = false
 			m.clampCursor()
-			return m, m.onCursorMove()
+			return m, tea.Batch(m.onCursorMove(), m.loadMoreIfNeeded())
 		}
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)
@@ -618,6 +618,25 @@ func (m Model) getS3URI() string {
 	return fmt.Sprintf("s3://%s/%s", m.bucket, objects[m.cursor].Key)
 }
 
+// loadMoreIfNeeded loads the next page if a filter is active and the filtered
+// results don't fill the visible list height.
+func (m *Model) loadMoreIfNeeded() tea.Cmd {
+	if m.bucket == "" {
+		return nil // buckets are not paginated
+	}
+	if m.search.Value() == "" {
+		return nil
+	}
+	if m.nextToken == nil || m.loadingMore {
+		return nil
+	}
+	if len(m.filteredObjects()) >= m.listHeight() {
+		return nil
+	}
+	m.loadingMore = true
+	return m.loadMoreCmd()
+}
+
 // Commands
 
 func (m Model) loadBucketsCmd() tea.Cmd {
@@ -864,6 +883,11 @@ func listenForProgress(ch <-chan tea.Msg) tea.Cmd {
 		}
 		return msg
 	}
+}
+
+// Searching reports whether the model has an active text input.
+func (m Model) Searching() bool {
+	return m.searching
 }
 
 // StatusHelp returns context-aware help text for the status bar.

--- a/internal/ui/s3/views.go
+++ b/internal/ui/s3/views.go
@@ -66,6 +66,8 @@ func (m Model) renderLeft() string {
 	// Search input
 	if m.searching {
 		fmt.Fprintln(b, m.search.View())
+	} else if m.search.Value() != "" {
+		fmt.Fprintln(b, statusStyle.Render(fmt.Sprintf("Filter: %s", m.search.Value())))
 	} else {
 		fmt.Fprintln(b, dimText.Render("Press / to filter"))
 	}


### PR DESCRIPTION
## Summary
- Display "Filter: <value>" in cyan when search is closed but filter is active, replacing the default "Press / to filter" hint across all four service views
- Auto-load next pagination pages when filtered results don't fill the visible list height, cascading until the screen is full or no more pages exist
- Prevent global shortcuts (q, r, s) from firing while a search input is focused via `Searching()` interface

## Test plan
- [ ] Press `/`, type a filter, press enter — verify "Filter: ..." indicator is shown in cyan
- [ ] Apply a restrictive filter with paginated data — verify more pages load automatically until the screen fills
- [ ] Press `/` again — verify filter is editable (Logs) or clears (S3/DynamoDB/Lambda)
- [ ] Verify `q`, `r`, `s` keys don't trigger quit/region/service while search input is focused
- [ ] Verify lazy-load indicator ("loading more...") appears during auto-load

🤖 Generated with [Claude Code](https://claude.com/claude-code)