### PR TITLE
fix: improve LocalStack dev workflow compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ go.work.sum
 
 # Claude Code
 .claude/
+
+# Demo recordings
+demos/*.mp4
+demos/*.gif
+demos/*.webm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,17 +54,17 @@ git config core.hooksPath .githooks
 
 ### Git Worktree Workflow
 
-Always use `git worktree` to create feature branches. This avoids conflicts with uncommitted work on the main branch and keeps the primary working tree clean.
+Always use `git worktree` to create feature or fix branches. This avoids conflicts with uncommitted work on the main branch and keeps the primary working tree clean.
 
 ```bash
 # Create a worktree with a new feature branch
-git worktree add ../sacha-<short-name> -b claude/<branch-name>
+git worktree add ../sacha-<short-name> -b feature/<branch-name>
 
 # Work, commit, and push from the worktree directory
 cd ../sacha-<short-name>
 # ... make changes ...
 git add <files> && git commit -m "feat: description"
-git push -u origin claude/<branch-name>
+git push -u origin feature/<branch-name>
 
 # Clean up after PR is merged
 git worktree remove ../sacha-<short-name>
@@ -73,7 +73,7 @@ git worktree remove ../sacha-<short-name>
 Key rules:
 - Never commit directly to `main` — always use a feature branch via worktree
 - Name worktree directories `../sacha-<short-name>` to keep them adjacent to the main repo
-- Name branches `claude/<descriptive-name>` for AI-authored changes
+- Name branches `feature/<descriptive-name>` or `fix/<descriptive-name>` for AI-authored changes
 - Remove worktrees after the PR is merged to avoid stale checkouts
 
 ### Version Information

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/version.Date=$(DATE)
 
 .PHONY: build test run lint clean install snapshot release-dry-run setup fmt \
-	local-up local-down local-seed local-run local-reset
+	local-up local-down local-seed local-seed-live local-run local-reset
 
 build:
 	@echo "Building $(APP) $(VERSION)..."
@@ -56,24 +56,28 @@ fmt:
 
 # LocalStack targets
 LOCAL_ENDPOINT := http://localhost:4566
-LOCAL_ENV := AWS_ENDPOINT_URL=$(LOCAL_ENDPOINT) AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1
+LOCAL_ENV := AWS_ENDPOINT_URL=$(LOCAL_ENDPOINT) AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 AWS_PAGER=""
+DOCKER_COMPOSE := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
 
 local-up:
-	@docker compose up -d
+	@$(DOCKER_COMPOSE) up -d
 	@echo "Waiting for LocalStack..."
-	@until curl -s $(LOCAL_ENDPOINT)/_localstack/health | grep -q '"s3": "available"'; do sleep 1; done
+	@until curl -s $(LOCAL_ENDPOINT)/_localstack/health | grep -qE '"s3": "(available|running)"'; do sleep 1; done
 	@echo "LocalStack is ready"
 
 local-down:
-	@docker compose down
+	@$(DOCKER_COMPOSE) down
 
 local-seed:
 	@$(LOCAL_ENV) bash scripts/seed-localstack.sh
+
+local-seed-live:
+	@$(LOCAL_ENV) bash scripts/seed-localstack-live.sh
 
 local-run: build
 	@$(LOCAL_ENV) ./bin/$(APP)
 
 local-reset:
-	@docker compose down -v
+	@$(DOCKER_COMPOSE) down -v
 	@$(MAKE) local-up
 	@$(MAKE) local-seed

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,55 @@
+# Demo Videos
+
+VHS tape files for recording Sacha demo videos.
+
+## Prerequisites
+
+1. **VHS** - Terminal recorder: `brew install vhs`
+2. **LocalStack** - Local AWS: `docker compose up -d`
+3. **Seed data**: `make local-seed`
+4. **Build**: `make build`
+
+## Quick Setup
+
+```bash
+# From project root
+make local-up && make local-seed && make build
+```
+
+## Available Demos
+
+### `sacha-quick.tape` — Quick Showcase (6-10s)
+
+Fast tour through all 4 services. Best for social media and README.
+
+```bash
+cd demos && vhs sacha-quick.tape
+```
+
+### `sacha-full.tape` — Full Demo (20-25s)
+
+Deeper feature exploration: log tailing, S3 browsing, DynamoDB scanning, Lambda filtering.
+
+Requires live log events for the tailing section:
+
+```bash
+# Terminal 1: start live events
+make local-seed-live
+
+# Terminal 2: record
+cd demos && vhs sacha-full.tape
+```
+
+## Output
+
+Recordings are saved as `.mp4` files in this directory (gitignored).
+
+## Customization
+
+Edit the `.tape` files to adjust:
+- `Set FontSize` — Text size (default: 16)
+- `Set Theme` — Color scheme (default: Catppuccin Mocha)
+- `Sleep` durations — Pacing between actions
+- `TypingSpeed` — How fast commands are typed
+
+See [VHS documentation](https://github.com/charmbracelet/vhs) for all options.

--- a/demos/sacha-full.tape
+++ b/demos/sacha-full.tape
@@ -1,0 +1,169 @@
+# Sacha Full Demo — 20-25s showcase with deeper feature exploration
+#
+# Prerequisites:
+#   make local-up && make local-seed && make local-seed-live &
+#   make build
+#
+# Record:
+#   cd demos && vhs sacha-full.tape
+#
+# Output: sacha-full.mp4 (1920x1080, ~22s)
+
+Output sacha-full.mp4
+
+Set Shell bash
+Set FontSize 16
+Set Width 1920
+Set Height 1080
+Set Padding 20
+Set TypingSpeed 40ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Launch sacha against LocalStack
+Hide
+Type "AWS_ENDPOINT_URL=http://localhost:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 ./bin/sacha --service cloudwatch-logs"
+Enter
+Sleep 2s
+Show
+
+# === CloudWatch Logs (0-5s) ===
+# Navigate log groups
+Sleep 300ms
+Type "j"
+Sleep 100ms
+Type "j"
+Sleep 100ms
+Type "j"
+Sleep 300ms
+
+# Select two groups
+Type " "
+Sleep 200ms
+Type "j"
+Sleep 100ms
+Type " "
+Sleep 300ms
+
+# Start tailing
+Type "t"
+Sleep 1500ms
+
+# Switch to tail panel
+Tab
+Sleep 400ms
+
+# Navigate tail events
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 400ms
+
+# Stop tailing
+Type "x"
+Sleep 400ms
+
+# === S3 (5-11s) ===
+Type "s"
+Sleep 400ms
+Type "s3"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Navigate to a bucket
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 300ms
+
+# Open bucket
+Enter
+Sleep 600ms
+
+# Navigate inside bucket
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 300ms
+
+# Open a folder
+Enter
+Sleep 600ms
+
+# Navigate files
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 300ms
+
+# Go back
+Escape
+Sleep 400ms
+Escape
+Sleep 400ms
+
+# === DynamoDB (11-17s) ===
+Type "s"
+Sleep 400ms
+Type "dyn"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Navigate tables
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 300ms
+
+# Open table to scan items
+Enter
+Sleep 800ms
+
+# Navigate items
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 300ms
+
+# Expand an item
+Enter
+Sleep 800ms
+
+# Close popup
+Escape
+Sleep 300ms
+
+# Go back to tables
+Escape
+Sleep 400ms
+
+# === Lambda (17-22s) ===
+Type "s"
+Sleep 400ms
+Type "lam"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Filter functions
+Type "/"
+Sleep 200ms
+Type "api"
+Sleep 400ms
+Enter
+Sleep 400ms
+
+# Expand function details
+Enter
+Sleep 1000ms
+
+# Close and quit
+Escape
+Sleep 400ms

--- a/demos/sacha-quick.tape
+++ b/demos/sacha-quick.tape
@@ -1,0 +1,98 @@
+# Sacha Quick Demo — 6-10s showcase of all 4 AWS services
+#
+# Prerequisites:
+#   make local-up && make local-seed && make build
+#
+# Record:
+#   cd demos && vhs sacha-quick.tape
+#
+# Output: sacha-quick.mp4 (1920x1080, ~8s)
+
+Output sacha-quick.mp4
+
+Set Shell bash
+Set FontSize 16
+Set Width 1920
+Set Height 1080
+Set Padding 20
+Set TypingSpeed 40ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# Launch sacha against LocalStack
+Hide
+Type "AWS_ENDPOINT_URL=http://localhost:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 ./bin/sacha --service cloudwatch-logs"
+Enter
+Sleep 2s
+Show
+
+# --- CloudWatch Logs (0-2s) ---
+# Show log groups list, navigate down
+Sleep 400ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 600ms
+
+# --- Switch to S3 (2-4s) ---
+Type "s"
+Sleep 400ms
+Type "s3"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Navigate S3 buckets
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 600ms
+
+# --- Switch to DynamoDB (4-6s) ---
+Type "s"
+Sleep 400ms
+Type "dyn"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Navigate DynamoDB tables
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 600ms
+
+# --- Switch to Lambda (6-8s) ---
+Type "s"
+Sleep 400ms
+Type "lam"
+Sleep 200ms
+Enter
+Sleep 600ms
+
+# Navigate Lambda functions
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 150ms
+Type "j"
+Sleep 400ms
+
+# Expand a function detail
+Enter
+Sleep 800ms
+
+# Close and end
+Escape
+Sleep 300ms

--- a/scripts/seed-localstack-live.sh
+++ b/scripts/seed-localstack-live.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# seed-localstack-live.sh — Continuously sends log events to LocalStack CloudWatch log groups.
+#
+# Prerequisites: make local-up && make local-seed
+#
+# Usage:
+#   make local-seed-live          # Terminal 1: generate events
+#   make local-run                # Terminal 2: tail them in the TUI
+#
+# Press Ctrl+C to stop.
+
+set -euo pipefail
+
+ENDPOINT="${AWS_ENDPOINT_URL:-http://localhost:4566}"
+REGION="${AWS_REGION:-us-east-1}"
+
+aws() {
+  command aws --endpoint-url "$ENDPOINT" --region "$REGION" "$@"
+}
+
+# Log groups seeded by seed-localstack.sh
+# Note: avoid "GROUPS" — it's a reserved bash variable (user's Unix group IDs).
+LOG_GROUPS=("/app/web" "/app/api" "/app/worker" "/aws/lambda/my-function")
+STREAM="stream-1"
+
+# Sample data pools
+LEVELS=("info" "info" "info" "warn" "error" "debug")
+PATHS_WEB=("GET /dashboard" "GET /users" "POST /login" "GET /settings" "PUT /users/123" "DELETE /sessions/abc" "GET /health")
+PATHS_API=("GET /api/v1/users" "POST /api/v1/orders" "GET /api/v1/products" "PUT /api/v1/cart" "GET /api/v1/search?q=test" "DELETE /api/v1/cache")
+WORKER_MSGS=("processing job" "job completed" "retrying failed task" "queue drained" "batch processed" "sending notification" "compressing archive")
+LAMBDA_MSGS=("invocation started" "cold start detected" "execution completed" "timeout warning" "memory usage high" "response sent")
+STATUS_CODES=(200 200 200 200 201 204 301 400 404 500 502)
+
+# rand_element ARRAY_NAME — prints a random element from the named array.
+# Compatible with bash 3.2 (no nameref needed).
+rand_element() {
+  local tmp="$1[@]"
+  local vals=("${!tmp}")
+  echo "${vals[$((RANDOM % ${#vals[@]}))]}"
+}
+
+rand_range() {
+  echo $(( $1 + RANDOM % ($2 - $1 + 1) ))
+}
+
+# Fetch the current sequence token for a log stream (needed by put-log-events).
+get_sequence_token() {
+  local group=$1
+  local token
+  token=$(aws logs describe-log-streams \
+    --log-group-name "$group" \
+    --log-stream-name-prefix "$STREAM" \
+    --query 'logStreams[0].uploadSequenceToken' \
+    --output text 2>/dev/null || echo "")
+  # "None" is returned when no token exists yet (first write)
+  if [[ "$token" == "None" || -z "$token" ]]; then
+    echo ""
+  else
+    echo "$token"
+  fi
+}
+
+put_events() {
+  local group=$1
+  local events=$2
+  local token
+  token=$(get_sequence_token "$group")
+
+  if [[ -n "$token" ]]; then
+    aws logs put-log-events \
+      --log-group-name "$group" \
+      --log-stream-name "$STREAM" \
+      --log-events "$events" \
+      --sequence-token "$token" > /dev/null 2>&1
+  else
+    aws logs put-log-events \
+      --log-group-name "$group" \
+      --log-stream-name "$STREAM" \
+      --log-events "$events" > /dev/null 2>&1
+  fi
+}
+
+build_event() {
+  local group=$1
+  local ts=$2
+  local level msg status duration request_id
+
+  level=$(rand_element LEVELS)
+  status=$(rand_element STATUS_CODES)
+  duration=$(rand_range 1 800)
+  request_id=$(printf '%04x-%04x' $((RANDOM)) $((RANDOM)))
+
+  case "$group" in
+    /app/web)
+      msg=$(rand_element PATHS_WEB)
+      ;;
+    /app/api)
+      msg=$(rand_element PATHS_API)
+      ;;
+    /app/worker)
+      msg=$(rand_element WORKER_MSGS)
+      ;;
+    /aws/lambda/*)
+      msg=$(rand_element LAMBDA_MSGS)
+      ;;
+  esac
+
+  local payload="{\\\"level\\\":\\\"$level\\\",\\\"msg\\\":\\\"$msg\\\",\\\"status\\\":$status,\\\"duration_ms\\\":$duration,\\\"request_id\\\":\\\"$request_id\\\"}"
+  echo "{\"timestamp\":$ts,\"message\":\"$payload\"}"
+}
+
+iteration=0
+
+echo "Sending live log events to LocalStack (Ctrl+C to stop)..."
+echo "  Groups: ${LOG_GROUPS[*]}"
+echo ""
+
+while true; do
+  iteration=$((iteration + 1))
+  now_ms=$(( $(date +%s) * 1000 ))
+
+  # Pick a random subset of groups (1 to all 4)
+  count=$(rand_range 1 ${#LOG_GROUPS[@]})
+  # Shuffle: swap each element with a random position
+  shuffled=("${LOG_GROUPS[@]}")
+  for ((i = ${#shuffled[@]} - 1; i > 0; i--)); do
+    j=$((RANDOM % (i + 1)))
+    tmp="${shuffled[$i]}"
+    shuffled[$i]="${shuffled[$j]}"
+    shuffled[$j]="$tmp"
+  done
+  selected=("${shuffled[@]:0:$count}")
+
+  for group in "${selected[@]}"; do
+    # Send 1-3 events per group
+    num_events=$(rand_range 1 3)
+    events=""
+    for ((e = 0; e < num_events; e++)); do
+      # Offset each event by a few ms so timestamps are unique
+      ev=$(build_event "$group" $((now_ms + e)))
+      if [[ -n "$events" ]]; then
+        events="$events,$ev"
+      else
+        events="$ev"
+      fi
+    done
+
+    put_events "$group" "[$events]"
+  done
+
+  # Brief status
+  printf "\r[#%d] Sent events to %d group(s): %s" "$iteration" "$count" "${selected[*]}"
+
+  # Sleep 2-3 seconds
+  sleep $(rand_range 2 3)
+done

--- a/scripts/seed-localstack.sh
+++ b/scripts/seed-localstack.sh
@@ -14,55 +14,70 @@ ENDPOINT="${AWS_ENDPOINT_URL:-http://localhost:4566}"
 REGION="${AWS_REGION:-us-east-1}"
 
 aws() {
-  command aws --endpoint-url "$ENDPOINT" --region "$REGION" "$@"
+  command aws --endpoint-url "$ENDPOINT" --region "$REGION" --no-cli-pager "$@"
+}
+
+# progress BAR_CURRENT BAR_TOTAL LABEL — inline progress indicator
+progress() {
+  local current=$1 total=$2 label=$3
+  printf "\r  %s %d/%d" "$label" "$current" "$total"
+  if [ "$current" -eq "$total" ]; then printf "\n"; fi
 }
 
 echo "=== Seeding S3 ==="
 
 # Create 5 buckets
 for bucket in sacha-logs sacha-data sacha-assets sacha-backups sacha-config; do
-  aws s3api create-bucket --bucket "$bucket" 2>/dev/null || true
+  aws s3api create-bucket --bucket "$bucket" > /dev/null 2>&1 || true
 done
+echo "  5 buckets created"
 
 # sacha-logs: nested folder structure with JSON/text files
 for folder in app/web app/api app/worker system; do
   for i in $(seq 1 5); do
     echo "{\"level\":\"info\",\"msg\":\"log entry $i\",\"service\":\"$folder\"}" | \
-      aws s3 cp - "s3://sacha-logs/$folder/log-$(printf '%03d' "$i").json"
+      aws s3 cp - "s3://sacha-logs/$folder/log-$(printf '%03d' "$i").json" --quiet
   done
 done
-echo "access log data" | aws s3 cp - "s3://sacha-logs/access.log"
-echo "error log data" | aws s3 cp - "s3://sacha-logs/error.log"
+echo "access log data" | aws s3 cp - "s3://sacha-logs/access.log" --quiet
+echo "error log data" | aws s3 cp - "s3://sacha-logs/error.log" --quiet
+echo "  sacha-logs: 22 objects"
 
 # sacha-data: 1200+ objects across folders (triggers pagination)
+count=0
+total=1200
 for folder in users orders products analytics; do
   for i in $(seq 1 300); do
     echo "{\"id\":$i,\"folder\":\"$folder\"}" | \
       aws s3 cp - "s3://sacha-data/$folder/item-$(printf '%04d' "$i").json" --quiet
+    count=$((count + 1))
+    progress "$count" "$total" "sacha-data:"
   done
 done
-echo "Seeded 1200 objects in sacha-data"
 
 # sacha-assets: images/media folder structure
 for folder in images/icons images/banners videos documents; do
   for i in $(seq 1 5); do
     echo "binary-placeholder-$i" | \
-      aws s3 cp - "s3://sacha-assets/$folder/file-$(printf '%03d' "$i").bin"
+      aws s3 cp - "s3://sacha-assets/$folder/file-$(printf '%03d' "$i").bin" --quiet
   done
 done
+echo "  sacha-assets: 20 objects"
 
 # sacha-backups: date-partitioned folders
 for month in 01 02 03 04 05 06; do
   for day in 01 15; do
     echo "{\"backup\":true,\"date\":\"2025-$month-$day\"}" | \
-      aws s3 cp - "s3://sacha-backups/2025/$month/$day/backup.json"
+      aws s3 cp - "s3://sacha-backups/2025/$month/$day/backup.json" --quiet
   done
 done
+echo "  sacha-backups: 12 objects"
 
 # sacha-config: small config files
-echo '{"app":"sacha","version":"1.0"}' | aws s3 cp - "s3://sacha-config/app.json"
-echo '{"database":{"host":"localhost","port":5432}}' | aws s3 cp - "s3://sacha-config/database.json"
-echo '{"logging":{"level":"info"}}' | aws s3 cp - "s3://sacha-config/logging.json"
+echo '{"app":"sacha","version":"1.0"}' | aws s3 cp - "s3://sacha-config/app.json" --quiet
+echo '{"database":{"host":"localhost","port":5432}}' | aws s3 cp - "s3://sacha-config/database.json" --quiet
+echo '{"logging":{"level":"info"}}' | aws s3 cp - "s3://sacha-config/logging.json" --quiet
+echo "  sacha-config: 3 objects"
 
 echo "=== Seeding CloudWatch Logs ==="
 
@@ -86,6 +101,7 @@ for group in /app/web /app/api /app/worker /aws/lambda/my-function; do
     --log-stream-name "stream-1" \
     --log-events "[$events]" > /dev/null
 done
+echo "  4 primary log groups (12 events each)"
 
 # 56 additional log groups for pagination (page size 50)
 for i in $(seq 1 56); do
@@ -107,8 +123,9 @@ for i in $(seq 1 56); do
     --log-group-name "$name" \
     --log-stream-name "stream-1" \
     --log-events "[$events]" > /dev/null
+  progress "$i" 56 "pagination groups:"
 done
-echo "Seeded 60 log groups"
+echo "  60 log groups total"
 
 echo "=== Seeding DynamoDB ==="
 
@@ -117,12 +134,13 @@ aws dynamodb create-table \
   --table-name Users \
   --attribute-definitions AttributeName=userId,AttributeType=S \
   --key-schema AttributeName=userId,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+  --billing-mode PAY_PER_REQUEST > /dev/null 2>&1 || true
 
 for i in $(seq 1 80); do
   aws dynamodb put-item --table-name Users --item \
     "{\"userId\":{\"S\":\"user-$(printf '%03d' "$i")\"},\"name\":{\"S\":\"User $i\"},\"email\":{\"S\":\"user$i@example.com\"},\"age\":{\"N\":\"$((20 + RANDOM % 50))\"},\"active\":{\"BOOL\":$([ $((i % 5)) -eq 0 ] && echo false || echo true)}}" \
     > /dev/null
+  progress "$i" 80 "Users items:"
 done
 
 # Orders table — 50 items (hash+range key), tests 2+ scan pages
@@ -134,12 +152,13 @@ aws dynamodb create-table \
   --key-schema \
     AttributeName=orderId,KeyType=HASH \
     AttributeName=createdAt,KeyType=RANGE \
-  --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+  --billing-mode PAY_PER_REQUEST > /dev/null 2>&1 || true
 
 for i in $(seq 1 50); do
   aws dynamodb put-item --table-name Orders --item \
     "{\"orderId\":{\"S\":\"order-$(printf '%03d' "$i")\"},\"createdAt\":{\"S\":\"2025-01-$(printf '%02d' $((i % 28 + 1)))T10:00:00Z\"},\"total\":{\"N\":\"$((RANDOM % 10000))\"},\"status\":{\"S\":\"$([ $((i % 3)) -eq 0 ] && echo shipped || echo pending)\"}}" \
     > /dev/null
+  progress "$i" 50 "Orders items:"
 done
 
 # Sessions table — 30 items
@@ -147,12 +166,13 @@ aws dynamodb create-table \
   --table-name Sessions \
   --attribute-definitions AttributeName=sessionId,AttributeType=S \
   --key-schema AttributeName=sessionId,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+  --billing-mode PAY_PER_REQUEST > /dev/null 2>&1 || true
 
 for i in $(seq 1 30); do
   aws dynamodb put-item --table-name Sessions --item \
     "{\"sessionId\":{\"S\":\"sess-$(printf '%03d' "$i")\"},\"userId\":{\"S\":\"user-$(printf '%03d' $((i % 80 + 1)))\"},\"ttl\":{\"N\":\"$(($(date +%s) + 3600))\"}}" \
     > /dev/null
+  progress "$i" 30 "Sessions items:"
 done
 
 # 117 additional empty tables for list pagination (page size 100)
@@ -161,9 +181,10 @@ for i in $(seq 1 117); do
     --table-name "table-$(printf '%03d' "$i")" \
     --attribute-definitions AttributeName=id,AttributeType=S \
     --key-schema AttributeName=id,KeyType=HASH \
-    --billing-mode PAY_PER_REQUEST 2>/dev/null || true
+    --billing-mode PAY_PER_REQUEST > /dev/null 2>&1 || true
+  progress "$i" 117 "pagination tables:"
 done
-echo "Seeded 120 DynamoDB tables"
+echo "  120 tables total (Users: 80, Orders: 50, Sessions: 30)"
 
 echo "=== Seeding Lambda ==="
 
@@ -180,7 +201,7 @@ aws lambda create-function \
   --role arn:aws:iam::000000000000:role/lambda-role \
   --zip-file "fileb://$TMPDIR/function.zip" \
   --environment "Variables={API_URL=https://api.example.com,LOG_LEVEL=info}" \
-  2>/dev/null || true
+  > /dev/null 2>&1 || true
 
 aws lambda create-function \
   --function-name data-processor \
@@ -190,7 +211,7 @@ aws lambda create-function \
   --zip-file "fileb://$TMPDIR/function.zip" \
   --environment "Variables={BATCH_SIZE=100,QUEUE_URL=https://sqs.example.com/queue}" \
   --timeout 300 --memory-size 512 \
-  2>/dev/null || true
+  > /dev/null 2>&1 || true
 
 # Node.js runtime
 echo 'exports.handler = async (event) => ({ statusCode: 200 });' > "$TMPDIR/index.js"
@@ -203,7 +224,7 @@ aws lambda create-function \
   --role arn:aws:iam::000000000000:role/lambda-role \
   --zip-file "fileb://$TMPDIR/node-function.zip" \
   --environment "Variables={EVENT_BUS=default}" \
-  2>/dev/null || true
+  > /dev/null 2>&1 || true
 
 aws lambda create-function \
   --function-name notification-sender \
@@ -212,7 +233,7 @@ aws lambda create-function \
   --role arn:aws:iam::000000000000:role/lambda-role \
   --zip-file "fileb://$TMPDIR/node-function.zip" \
   --timeout 30 --memory-size 256 \
-  2>/dev/null || true
+  > /dev/null 2>&1 || true
 
 aws lambda create-function \
   --function-name health-checker \
@@ -221,7 +242,9 @@ aws lambda create-function \
   --role arn:aws:iam::000000000000:role/lambda-role \
   --zip-file "fileb://$TMPDIR/function.zip" \
   --timeout 10 --memory-size 128 \
-  2>/dev/null || true
+  > /dev/null 2>&1 || true
+
+echo "  5 primary functions"
 
 # 60 additional functions for list pagination (page size 50)
 for i in $(seq 1 60); do
@@ -231,9 +254,10 @@ for i in $(seq 1 60); do
     --handler lambda_function.handler \
     --role arn:aws:iam::000000000000:role/lambda-role \
     --zip-file "fileb://$TMPDIR/function.zip" \
-    2>/dev/null || true
+    > /dev/null 2>&1 || true
+  progress "$i" 60 "pagination functions:"
 done
-echo "Seeded 65 Lambda functions"
+echo "  65 functions total"
 
 rm -rf "$TMPDIR"
 
@@ -241,4 +265,3 @@ echo ""
 echo "=== Seeding complete ==="
 echo "Run sacha against LocalStack:"
 echo "  make local-run"
-echo "  # or: ./bin/sacha --endpoint http://localhost:4566 --region us-east-1"


### PR DESCRIPTION
## Summary

- Auto-detect `docker-compose` vs `docker compose` for older Docker installs
- Accept both `"available"` and `"running"` S3 health status (newer LocalStack versions)
- Use `grep -qE` for macOS BSD grep compatibility (fixes infinite loop opening vi)
- Disable AWS CLI pager (`AWS_PAGER=""`) to prevent vi opening on seed output
- Add `--no-cli-pager` + suppress all JSON output in seed script
- Add inline progress counters for long seed loops (1200 S3 objects, 117 DynamoDB tables, 60 Lambda functions)
- Add `local-seed-live` Makefile target
- Add VHS demo tape files for recording TUI showcases
- Update worktree branch naming convention to `feature/`/`fix/` prefixes

## Test plan

- [ ] `make local-up` completes without hanging or opening vi
- [ ] `make local-seed` shows progress and completes without pager interruption
- [ ] `make local-run` launches the TUI against LocalStack
- [ ] `vhs demos/sacha-quick.tape` records a demo (with LocalStack running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)