### PR TITLE
fix(ui): account for scroll indicator in cursor visibility check

### DIFF
--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -326,8 +326,18 @@ func (m *Model) ensureCursorVisible() {
 	if m.cursor < m.listOffset {
 		m.listOffset = m.cursor
 	}
-	if m.cursor >= m.listOffset+visibleHeight {
-		m.listOffset = m.cursor - visibleHeight + 1
+	// When scrolled past the top, the "↑ more above" indicator takes one
+	// line from the visible area, so reduce the effective height.
+	effective := visibleHeight
+	if m.listOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
+	if m.cursor >= m.listOffset+effective {
+		m.listOffset = m.cursor - effective + 1
 	}
 	if m.listOffset < 0 {
 		m.listOffset = 0

--- a/internal/ui/lambda/model.go
+++ b/internal/ui/lambda/model.go
@@ -241,8 +241,18 @@ func (m *Model) ensureCursorVisible() {
 	if m.cursor < m.listOffset {
 		m.listOffset = m.cursor
 	}
-	if m.cursor >= m.listOffset+visibleHeight {
-		m.listOffset = m.cursor - visibleHeight + 1
+	// When scrolled past the top, the "↑ more above" indicator takes one
+	// line from the visible area, so reduce the effective height.
+	effective := visibleHeight
+	if m.listOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
+	if m.cursor >= m.listOffset+effective {
+		m.listOffset = m.cursor - effective + 1
 	}
 	if m.listOffset < 0 {
 		m.listOffset = 0

--- a/internal/ui/s3/model.go
+++ b/internal/ui/s3/model.go
@@ -386,9 +386,19 @@ func (m *Model) ensureCursorVisible() {
 		m.listOffset = m.cursor
 	}
 
+	// When scrolled past the top, the "↑ more above" indicator takes one
+	// line from the visible area, so reduce the effective height.
+	effective := visibleHeight
+	if m.listOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
 	// If cursor is below visible area, scroll down
-	if m.cursor >= m.listOffset+visibleHeight {
-		m.listOffset = m.cursor - visibleHeight + 1
+	if m.cursor >= m.listOffset+effective {
+		m.listOffset = m.cursor - effective + 1
 	}
 
 	// Clamp offset


### PR DESCRIPTION
## Summary\n- Fix cursor disappearing when scrolling near end of list in S3, DynamoDB, and Lambda views\n- The "↑ more above" scroll indicator takes one line from the visible area, but  wasn't accounting for it — causing a one-line mismatch\n- Apply the same effective-height pattern already used in CloudWatch Logs\n\n## Changes\n-  — reduce effective visible height by 1 when scroll indicator is shown\n-  — same fix\n-  — same fix\n\n## Test plan\n- [x] Building sacha v0.5.1-1-g37d5591... succeeds\n- [x] ?   	github.com/sachamama/sacha/cmd/sacha	[no test files]
ok  	github.com/sachamama/sacha/internal/aws	(cached)
ok  	github.com/sachamama/sacha/internal/config	(cached)
ok  	github.com/sachamama/sacha/internal/dynamodb	(cached)
ok  	github.com/sachamama/sacha/internal/lambda	(cached)
ok  	github.com/sachamama/sacha/internal/logs	(cached)
ok  	github.com/sachamama/sacha/internal/s3	(cached)
?   	github.com/sachamama/sacha/internal/ui/app	[no test files]
ok  	github.com/sachamama/sacha/internal/ui/dynamodb	(cached)
?   	github.com/sachamama/sacha/internal/ui/lambda	[no test files]
?   	github.com/sachamama/sacha/internal/ui/logs	[no test files]
?   	github.com/sachamama/sacha/internal/ui/s3	[no test files]
?   	github.com/sachamama/sacha/internal/version	[no test files] — all tests pass\n- [x] Pre-commit hooks pass (format, lint, tests)\n- [ ] S3: Open bucket with 300+ objects, scroll to end with  — cursor stays visible\n- [x] DynamoDB: Scroll through tables list — cursor stays visible\n- [ ] Lambda: Scroll through functions list — cursor stays visible\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n