### PR TITLE
feat(logs): add retention management, delete, and details pane

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,107 @@
+# Sacha Roadmap
+
+Planned features and new AWS services, building on Sacha's existing TUI patterns.
+
+## Phase 1: CloudWatch Logs Enhancements
+
+Quick wins that extend the existing CloudWatch Logs service with high-value operations.
+
+### Set Retention Policy (`R` key)
+
+Add a retention picker to set retention on selected log groups. Show standard options: 1d, 3d, 5d, 7d, 14d, 30d, 60d, 90d, 1y, never.
+
+- AWS API: `PutRetentionPolicy`
+- Reuses existing multi-select pattern
+- Files: `internal/logs/client.go`, `internal/ui/logs/model.go`
+
+### Delete Log Groups (`D` key)
+
+Delete selected log groups with a confirmation prompt. Multi-select already works.
+
+- AWS API: `DeleteLogGroup`
+- Needs confirmation overlay (y/n)
+- Files: `internal/logs/client.go`, `internal/ui/logs/model.go`
+
+### Show Creation Date
+
+Display log group creation date in the right-pane details. `DescribeLogGroups` already returns `creationTime` — just format and display it.
+
+- No new API calls needed
+- Files: `internal/ui/logs/views.go`
+
+## Phase 2: SSM Parameter Store Browser
+
+Browse parameters by path hierarchy, reusing S3's folder-navigation and scroll-stack patterns.
+
+- Left pane: path tree (`/app/prod/db-host`, `/app/prod/db-port`, ...)
+- Right pane: parameter value, type, version, last modified
+- `y` to copy value
+- `enter` to navigate into path prefix
+- `esc/backspace` to go back up
+
+### AWS APIs
+
+- `GetParametersByPath` — list parameters under a prefix
+- `GetParameter` — fetch single parameter value
+- `DescribeParameters` — metadata and filtering
+
+### Architecture
+
+- `internal/ssm/client.go` + `internal/ssm/types.go`
+- `internal/ui/ssm/service.go` + `internal/ui/ssm/model.go`
+- Scroll memory via `scrollStack` (same as S3)
+
+## Phase 3: SQS Queue Browser
+
+Browse queues with message count stats. Peek messages and optionally tail incoming messages using the CloudWatch tailing pattern.
+
+- Left pane: queue list with message counts
+- Right pane: queue attributes (type, visibility timeout, redrive policy)
+- `enter` to peek messages (`ReceiveMessage` with visibility timeout 0)
+- Potential tail mode for watching incoming messages
+
+### AWS APIs
+
+- `ListQueues` — list all queues
+- `GetQueueAttributes` — message counts, configuration
+- `ReceiveMessage` — peek at messages
+
+### Architecture
+
+- `internal/sqs/client.go` + `internal/sqs/types.go`
+- `internal/ui/sqs/service.go` + `internal/ui/sqs/model.go`
+- Optional `Tailing()` interface for live message watching
+
+## Phase 4: EC2 Browser
+
+Start with instances-only, expand to sub-resources later.
+
+### 4a: EC2 Instances
+
+- Browse instances with state, type, IP, name tag
+- Start/stop instances with confirmation
+- View full instance details in expandable popup
+
+### 4b: EC2 Sub-Resources (future)
+
+- EBS volumes (find unattached)
+- Elastic IPs (find unassociated)
+- Security groups (view rules, find unused)
+- Key pairs (find unused)
+
+### AWS APIs
+
+- `DescribeInstances`, `StartInstances`, `StopInstances`
+- `DescribeVolumes`, `DescribeAddresses`, `DescribeSecurityGroups`, `DescribeKeyPairs`
+
+## Future Considerations
+
+Services evaluated but deferred due to complexity or niche use:
+
+| Service | Notes |
+|---------|-------|
+| CloudFormation | Stacks + resources + events view. "Find stack by resource" is a unique feature |
+| Secrets Manager | Simple list + view, but sensitive (secrets display needs masking) |
+| ECS | Very valuable but deeply nested hierarchy (cluster > service > task > container) |
+| IAM | Global service (not regional), many sub-resource types |
+| Multi-Account Switcher | Cross-cutting concern needing STS assume-role integration |

--- a/internal/logs/client.go
+++ b/internal/logs/client.go
@@ -14,6 +14,9 @@ type CloudWatchLogsAPI interface {
 	DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 	FilterLogEvents(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
 	CreateLogGroup(ctx context.Context, params *cloudwatchlogs.CreateLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogGroupOutput, error)
+	DeleteLogGroup(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error)
+	PutRetentionPolicy(ctx context.Context, params *cloudwatchlogs.PutRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutRetentionPolicyOutput, error)
+	DeleteRetentionPolicy(ctx context.Context, params *cloudwatchlogs.DeleteRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error)
 }
 
 type Client struct {
@@ -30,6 +33,7 @@ type LogGroup struct {
 	Name          string
 	RetentionDays int32
 	StoredBytes   int64
+	CreationTime  time.Time
 }
 
 type TailEvent struct {
@@ -51,10 +55,15 @@ func (c *Client) ListLogGroups(ctx context.Context, nextToken *string) ([]LogGro
 
 	groups := make([]LogGroup, 0, len(out.LogGroups))
 	for _, g := range out.LogGroups {
+		var created time.Time
+		if g.CreationTime != nil {
+			created = time.Unix(0, *g.CreationTime*int64(time.Millisecond))
+		}
 		groups = append(groups, LogGroup{
 			Name:          aws.ToString(g.LogGroupName),
 			RetentionDays: aws.ToInt32(g.RetentionInDays),
 			StoredBytes:   aws.ToInt64(g.StoredBytes),
+			CreationTime:  created,
 		})
 	}
 
@@ -107,4 +116,37 @@ func (c *Client) FetchEvents(ctx context.Context, groups []string, start time.Ti
 		nextStart = events[len(events)-1].Timestamp.Add(time.Millisecond)
 	}
 	return events, nextStart, nil
+}
+
+// DeleteLogGroup deletes a log group by name.
+func (c *Client) DeleteLogGroup(ctx context.Context, name string) error {
+	_, err := c.api.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: aws.String(name),
+	})
+	if err != nil {
+		return fmt.Errorf("delete log group: %w", err)
+	}
+	return nil
+}
+
+// SetRetentionPolicy sets the retention policy on a log group.
+// Use retentionDays=0 to remove the retention policy (never expire).
+func (c *Client) SetRetentionPolicy(ctx context.Context, name string, retentionDays int32) error {
+	if retentionDays == 0 {
+		_, err := c.api.DeleteRetentionPolicy(ctx, &cloudwatchlogs.DeleteRetentionPolicyInput{
+			LogGroupName: aws.String(name),
+		})
+		if err != nil {
+			return fmt.Errorf("delete retention policy: %w", err)
+		}
+		return nil
+	}
+	_, err := c.api.PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String(name),
+		RetentionInDays: aws.Int32(retentionDays),
+	})
+	if err != nil {
+		return fmt.Errorf("put retention policy: %w", err)
+	}
+	return nil
 }

--- a/internal/logs/client_test.go
+++ b/internal/logs/client_test.go
@@ -13,9 +13,12 @@ import (
 
 // mockCloudWatchLogsAPI is a mock implementation of CloudWatchLogsAPI for testing.
 type mockCloudWatchLogsAPI struct {
-	describeLogGroupsFn func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
-	filterLogEventsFn   func(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
-	createLogGroupFn    func(ctx context.Context, params *cloudwatchlogs.CreateLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogGroupOutput, error)
+	describeLogGroupsFn     func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	filterLogEventsFn       func(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
+	createLogGroupFn        func(ctx context.Context, params *cloudwatchlogs.CreateLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.CreateLogGroupOutput, error)
+	deleteLogGroupFn        func(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error)
+	putRetentionPolicyFn    func(ctx context.Context, params *cloudwatchlogs.PutRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutRetentionPolicyOutput, error)
+	deleteRetentionPolicyFn func(ctx context.Context, params *cloudwatchlogs.DeleteRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error)
 }
 
 func (m *mockCloudWatchLogsAPI) DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
@@ -37,6 +40,27 @@ func (m *mockCloudWatchLogsAPI) CreateLogGroup(ctx context.Context, params *clou
 		return m.createLogGroupFn(ctx, params, optFns...)
 	}
 	return &cloudwatchlogs.CreateLogGroupOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsAPI) DeleteLogGroup(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
+	if m.deleteLogGroupFn != nil {
+		return m.deleteLogGroupFn(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.DeleteLogGroupOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsAPI) PutRetentionPolicy(ctx context.Context, params *cloudwatchlogs.PutRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
+	if m.putRetentionPolicyFn != nil {
+		return m.putRetentionPolicyFn(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.PutRetentionPolicyOutput{}, nil
+}
+
+func (m *mockCloudWatchLogsAPI) DeleteRetentionPolicy(ctx context.Context, params *cloudwatchlogs.DeleteRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error) {
+	if m.deleteRetentionPolicyFn != nil {
+		return m.deleteRetentionPolicyFn(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.DeleteRetentionPolicyOutput{}, nil
 }
 
 func TestListLogGroups(t *testing.T) {
@@ -371,5 +395,183 @@ func TestFetchEventsLogGroupAssignment(t *testing.T) {
 
 	if events[0].LogGroup != "/my/log/group" {
 		t.Errorf("LogGroup = %q, want %q", events[0].LogGroup, "/my/log/group")
+	}
+}
+
+func TestDeleteLogGroup(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupName string
+		mockFn    func(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error)
+		wantErr   bool
+	}{
+		{
+			name:      "successful deletion",
+			groupName: "/aws/lambda/my-function",
+			mockFn: func(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
+				if params.LogGroupName == nil || *params.LogGroupName != "/aws/lambda/my-function" {
+					t.Errorf("expected LogGroupName to be '/aws/lambda/my-function', got %v", params.LogGroupName)
+				}
+				return &cloudwatchlogs.DeleteLogGroupOutput{}, nil
+			},
+			wantErr: false,
+		},
+		{
+			name:      "API error - not found",
+			groupName: "/aws/lambda/missing",
+			mockFn: func(ctx context.Context, params *cloudwatchlogs.DeleteLogGroupInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
+				return nil, errors.New("ResourceNotFoundException")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				api: &mockCloudWatchLogsAPI{deleteLogGroupFn: tt.mockFn},
+			}
+
+			err := client.DeleteLogGroup(context.Background(), tt.groupName)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DeleteLogGroup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSetRetentionPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		groupName     string
+		retentionDays int32
+		wantPut       bool // expect PutRetentionPolicy call
+		wantDelete    bool // expect DeleteRetentionPolicy call
+		putErr        error
+		deleteErr     error
+		wantErr       bool
+	}{
+		{
+			name:          "set 30 day retention",
+			groupName:     "/aws/lambda/func1",
+			retentionDays: 30,
+			wantPut:       true,
+			wantErr:       false,
+		},
+		{
+			name:          "remove retention (never expire)",
+			groupName:     "/aws/lambda/func1",
+			retentionDays: 0,
+			wantDelete:    true,
+			wantErr:       false,
+		},
+		{
+			name:          "put retention API error",
+			groupName:     "/aws/lambda/func1",
+			retentionDays: 7,
+			wantPut:       true,
+			putErr:        errors.New("access denied"),
+			wantErr:       true,
+		},
+		{
+			name:          "delete retention API error",
+			groupName:     "/aws/lambda/func1",
+			retentionDays: 0,
+			wantDelete:    true,
+			deleteErr:     errors.New("access denied"),
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			putCalled := false
+			deleteCalled := false
+
+			client := &Client{
+				api: &mockCloudWatchLogsAPI{
+					putRetentionPolicyFn: func(ctx context.Context, params *cloudwatchlogs.PutRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
+						putCalled = true
+						if *params.LogGroupName != tt.groupName {
+							t.Errorf("LogGroupName = %q, want %q", *params.LogGroupName, tt.groupName)
+						}
+						if *params.RetentionInDays != tt.retentionDays {
+							t.Errorf("RetentionInDays = %d, want %d", *params.RetentionInDays, tt.retentionDays)
+						}
+						if tt.putErr != nil {
+							return nil, tt.putErr
+						}
+						return &cloudwatchlogs.PutRetentionPolicyOutput{}, nil
+					},
+					deleteRetentionPolicyFn: func(ctx context.Context, params *cloudwatchlogs.DeleteRetentionPolicyInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error) {
+						deleteCalled = true
+						if *params.LogGroupName != tt.groupName {
+							t.Errorf("LogGroupName = %q, want %q", *params.LogGroupName, tt.groupName)
+						}
+						if tt.deleteErr != nil {
+							return nil, tt.deleteErr
+						}
+						return &cloudwatchlogs.DeleteRetentionPolicyOutput{}, nil
+					},
+				},
+			}
+
+			err := client.SetRetentionPolicy(context.Background(), tt.groupName, tt.retentionDays)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("SetRetentionPolicy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantPut && !putCalled {
+				t.Error("expected PutRetentionPolicy to be called")
+			}
+			if tt.wantDelete && !deleteCalled {
+				t.Error("expected DeleteRetentionPolicy to be called")
+			}
+			if !tt.wantPut && putCalled {
+				t.Error("unexpected PutRetentionPolicy call")
+			}
+			if !tt.wantDelete && deleteCalled {
+				t.Error("unexpected DeleteRetentionPolicy call")
+			}
+		})
+	}
+}
+
+func TestListLogGroupsCreationTime(t *testing.T) {
+	creationMs := int64(1705312800000) // 2024-01-15T10:00:00Z
+
+	client := &Client{
+		api: &mockCloudWatchLogsAPI{
+			describeLogGroupsFn: func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+				return &cloudwatchlogs.DescribeLogGroupsOutput{
+					LogGroups: []types.LogGroup{
+						{
+							LogGroupName: aws.String("/test/group"),
+							CreationTime: &creationMs,
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	groups, _, err := client.ListLogGroups(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+
+	if groups[0].CreationTime.IsZero() {
+		t.Error("CreationTime should not be zero")
+	}
+
+	expected := time.Unix(0, creationMs*int64(time.Millisecond))
+	if !groups[0].CreationTime.Equal(expected) {
+		t.Errorf("CreationTime = %v, want %v", groups[0].CreationTime, expected)
 	}
 }

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -44,6 +44,38 @@ type logGroupCreatedMsg struct {
 	err  error
 }
 
+type logGroupsDeletedMsg struct {
+	names []string
+	err   error
+}
+
+type retentionSetMsg struct {
+	names []string
+	days  int32
+	err   error
+}
+
+// retentionOption represents a selectable retention period.
+type retentionOption struct {
+	label string
+	days  int32 // 0 means never expire
+}
+
+var retentionOptions = []retentionOption{
+	{"1 day", 1},
+	{"3 days", 3},
+	{"5 days", 5},
+	{"7 days", 7},
+	{"14 days", 14},
+	{"30 days", 30},
+	{"60 days", 60},
+	{"90 days", 90},
+	{"120 days", 120},
+	{"180 days", 180},
+	{"365 days", 365},
+	{"Never expire", 0},
+}
+
 type panel int
 
 const (
@@ -71,6 +103,11 @@ type Model struct {
 
 	creating    bool
 	createInput textinput.Model
+
+	deleting         bool // showing delete confirmation
+	deleteTargets    []string
+	settingRetention bool // showing retention picker
+	retentionCursor  int
 
 	tailing      bool
 	tailStart    time.Time
@@ -155,6 +192,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusLine = fmt.Sprintf("Created log group: %s", msg.name)
 		m.loading = true
 		return m, m.loadLogGroupsCmd()
+	case logGroupsDeletedMsg:
+		if msg.err != nil {
+			m.statusLine = msg.err.Error()
+			return m, nil
+		}
+		// Remove deleted groups from local state
+		for _, name := range msg.names {
+			delete(m.selected, name)
+		}
+		m.statusLine = fmt.Sprintf("Deleted %d log group(s)", len(msg.names))
+		m.loading = true
+		return m, m.loadLogGroupsCmd()
+	case retentionSetMsg:
+		if msg.err != nil {
+			m.statusLine = msg.err.Error()
+			return m, nil
+		}
+		label := fmt.Sprintf("%d days", msg.days)
+		if msg.days == 0 {
+			label = "never expire"
+		}
+		m.statusLine = fmt.Sprintf("Set retention to %s on %d group(s)", label, len(msg.names))
+		m.loading = true
+		return m, m.loadLogGroupsCmd()
 
 	case tea.KeyMsg:
 		if m.creating {
@@ -174,6 +235,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.createInput, cmd = m.createInput.Update(msg)
 			return m, cmd
+		}
+
+		if m.deleting {
+			switch msg.String() {
+			case "y", "Y":
+				m.deleting = false
+				targets := m.deleteTargets
+				m.deleteTargets = nil
+				m.statusLine = fmt.Sprintf("Deleting %d log group(s)...", len(targets))
+				return m, m.deleteLogGroupsCmd(targets)
+			case "n", "N", "esc":
+				m.deleting = false
+				m.deleteTargets = nil
+				m.statusLine = ""
+			}
+			return m, nil
+		}
+
+		if m.settingRetention {
+			switch msg.String() {
+			case "up", "k":
+				if m.retentionCursor > 0 {
+					m.retentionCursor--
+				}
+			case "down", "j":
+				if m.retentionCursor < len(retentionOptions)-1 {
+					m.retentionCursor++
+				}
+			case "enter":
+				m.settingRetention = false
+				opt := retentionOptions[m.retentionCursor]
+				targets := m.selectedGroups()
+				label := opt.label
+				m.statusLine = fmt.Sprintf("Setting retention to %s on %d group(s)...", label, len(targets))
+				return m, m.setRetentionCmd(targets, opt.days)
+			case "esc", "q":
+				m.settingRetention = false
+				m.statusLine = ""
+			}
+			return m, nil
 		}
 
 		if m.searching {
@@ -324,6 +425,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.createInput.SetValue("")
 				return m, m.createInput.Focus()
 			}
+		case "d", "D":
+			if !m.tailing {
+				targets := m.selectedGroups()
+				if len(targets) > 0 {
+					m.deleting = true
+					m.deleteTargets = targets
+				}
+			}
+		case "R":
+			if !m.tailing {
+				targets := m.selectedGroups()
+				if len(targets) > 0 {
+					m.settingRetention = true
+					m.retentionCursor = 0
+				}
+			}
 		case "t":
 			if !m.tailing && len(m.selectedGroups()) > 0 {
 				m.tailing = true
@@ -458,6 +575,18 @@ func (m Model) View() string {
 			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
 	}
 
+	if m.deleting {
+		popup := m.renderDeleteConfirm()
+		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
+			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
+	}
+
+	if m.settingRetention {
+		popup := m.renderRetentionPicker()
+		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
+			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
+	}
+
 	if m.expandedEvent >= 0 && m.expandedEvent < len(m.events) {
 		popup := m.renderExpandedEvent(m.events[m.expandedEvent])
 		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
@@ -524,6 +653,30 @@ func (m Model) createLogGroupCmd(name string) tea.Cmd {
 	}
 }
 
+func (m Model) deleteLogGroupsCmd(names []string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		for _, name := range names {
+			if err := m.client.DeleteLogGroup(ctx, name); err != nil {
+				return logGroupsDeletedMsg{err: err}
+			}
+		}
+		return logGroupsDeletedMsg{names: names}
+	}
+}
+
+func (m Model) setRetentionCmd(names []string, days int32) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		for _, name := range names {
+			if err := m.client.SetRetentionPolicy(ctx, name, days); err != nil {
+				return retentionSetMsg{err: err}
+			}
+		}
+		return retentionSetMsg{names: names, days: days}
+	}
+}
+
 func (m Model) filteredGroups() []logs.LogGroup {
 	if !m.searching && m.search.Value() == "" {
 		return m.logGroups
@@ -586,15 +739,21 @@ func (m Model) Tailing() bool {
 	return m.tailing
 }
 
-// Searching reports whether the model has an active text input.
+// Searching reports whether the model has an active text input or overlay.
 func (m Model) Searching() bool {
-	return m.searching || m.creating
+	return m.searching || m.creating || m.deleting || m.settingRetention
 }
 
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
 	if m.expandedEvent >= 0 {
 		return "↑↓ scroll, pgup/pgdn page, esc close"
+	}
+	if m.deleting {
+		return "y confirm delete, n/esc cancel"
+	}
+	if m.settingRetention {
+		return "↑↓ move, enter select, esc cancel"
 	}
 	if m.creating {
 		return "enter create, esc cancel"
@@ -619,7 +778,7 @@ func (m Model) StatusHelp() string {
 		}
 		return fmt.Sprintf("↑↓ move, enter expand, v [%s], tab/← switch, f fullscreen, x/q stop", viewMode)
 	}
-	return "↑↓ move, / search, space select, a all, c create, t tail"
+	return "↑↓ move, / search, space select, a all, c create, d delete, R retention, t tail"
 }
 
 func (m *Model) setViewportSize(bodyHeight int) {

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -50,6 +50,13 @@ var (
 	statusStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("44"))
 
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("33"))
+
+	warnStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("196")).
+			Bold(true)
+
 	popupStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("63")).
@@ -120,9 +127,42 @@ func (m Model) renderGroups() string {
 
 func (m Model) renderTail() string {
 	if !m.tailing {
-		return fmt.Sprintf("%s\n%s", titleStyle.Render("Logs"), dimText.Render("Press t to start tailing selected groups"))
+		return m.renderGroupDetails()
 	}
 	return fmt.Sprintf("%s\n%s", titleStyle.Render("Logs"), m.view.View())
+}
+
+func (m Model) renderGroupDetails() string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, titleStyle.Render("Log Group Details"))
+
+	groups := m.filteredGroups()
+	if len(groups) == 0 || m.cursor >= len(groups) {
+		fmt.Fprintln(b)
+		fmt.Fprintln(b, dimText.Render("No log group selected"))
+		return b.String()
+	}
+
+	g := groups[m.cursor]
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), g.Name)
+
+	if g.RetentionDays > 0 {
+		fmt.Fprintf(b, "%s  %d days\n", labelStyle.Render("Retention:"), g.RetentionDays)
+	} else {
+		fmt.Fprintf(b, "%s  Never expire\n", labelStyle.Render("Retention:"))
+	}
+
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Stored:"), formatBytes(g.StoredBytes))
+
+	if !g.CreationTime.IsZero() {
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Created:"), g.CreationTime.Format("2006-01-02 15:04:05"))
+	}
+
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("Press t to start tailing selected groups"))
+
+	return b.String()
 }
 
 func renderEvents(events []logs.TailEvent, jsonView bool, cursor, width int, showCursor bool, scrollX int) string {
@@ -396,6 +436,19 @@ func formatValue(v interface{}) string {
 	}
 }
 
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
 func checkbox(selected bool) string {
 	if selected {
 		return "x"
@@ -458,4 +511,39 @@ func initExpandedView(e logs.TailEvent, width, height int) viewport.Model {
 	vp := viewport.New(maxWidth-4, viewportHeight)
 	vp.SetContent(msg)
 	return vp
+}
+
+func (m Model) renderDeleteConfirm() string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, warnStyle.Render("Delete Log Groups"))
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "Delete %d log group(s)?\n", len(m.deleteTargets))
+	fmt.Fprintln(b)
+	for i, name := range m.deleteTargets {
+		if i >= 10 {
+			fmt.Fprintf(b, "  ... and %d more\n", len(m.deleteTargets)-10)
+			break
+		}
+		fmt.Fprintf(b, "  %s\n", name)
+	}
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("y to confirm, n/esc to cancel"))
+	return popupStyle.Render(b.String())
+}
+
+func (m Model) renderRetentionPicker() string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, titleStyle.Render("Set Retention Policy"))
+	fmt.Fprintf(b, "%s\n", dimText.Render(fmt.Sprintf("Apply to %d selected group(s)", len(m.selectedGroups()))))
+	fmt.Fprintln(b)
+	for i, opt := range retentionOptions {
+		if i == m.retentionCursor {
+			fmt.Fprintf(b, "  %s %s\n", hoverPointer, cursorStyle.Render(opt.label))
+		} else {
+			fmt.Fprintf(b, "    %s\n", opt.label)
+		}
+	}
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("↑↓ move, enter select, esc cancel"))
+	return popupStyle.Render(b.String())
 }


### PR DESCRIPTION
## Summary
- Add `R` key to set retention policy on selected log groups via picker (1d–365d or never expire)
- Add `D` key to delete selected log groups with y/n confirmation prompt
- Show log group details (name, retention, stored bytes, creation date) in right pane when not tailing
- Add `ROADMAP.md` with planned features across 4 phases

## Changes
- `internal/logs/client.go` — Add `DeleteLogGroup`, `SetRetentionPolicy`, `CreationTime` field
- `internal/logs/client_test.go` — Tests for new client methods and creation time parsing
- `internal/ui/logs/model.go` — New states (deleting, settingRetention), key handlers, commands, message types
- `internal/ui/logs/views.go` — Details pane, delete confirmation popup, retention picker popup
- `ROADMAP.md` — Project roadmap (Phase 1–4)

## Test plan
- [x] `make build` succeeds
- [x] `make test` — all tests pass (including 3 new test functions)
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, tests)
- [ ] Select log groups, press `R` — retention picker appears, select option, retention updates
- [ ] Select log groups, press `D` — confirmation appears, press `y` to delete
- [ ] Navigate log groups without tailing — right pane shows details with creation date

🤖 Generated with [Claude Code](https://claude.com/claude-code)