### PR TITLE
feat(sqs): add SQS Queue Browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Access version info via CLI: `sacha --version`
    - `internal/dynamodb/` - DynamoDB
    - `internal/lambda/` - Lambda
    - `internal/ssm/` - SSM Parameter Store
+   - `internal/sqs/` - SQS
 5. **UI** (`internal/ui/`) - Bubble Tea TUI framework
    - `app/` - Main application shell (region/service switching)
    - `logs/` - CloudWatch Logs specific UI
@@ -104,6 +105,7 @@ Access version info via CLI: `sacha --version`
    - `dynamodb/` - DynamoDB browser UI
    - `lambda/` - Lambda browser UI
    - `ssm/` - SSM Parameter Store browser UI
+   - `sqs/` - SQS Queue browser UI
 
 ### Plugin Architecture
 
@@ -238,6 +240,7 @@ Each AWS service uses token-based pagination. The client methods accept a pagina
 | Lambda | ListFunctions | `Marker` / `NextMarker` | 50 | `internal/lambda/client.go` |
 | SSM | GetParametersByPath | `NextToken` | 50 | `internal/ssm/client.go` |
 | SSM | DescribeParameters | `NextToken` | 50 | `internal/ssm/client.go` |
+| SQS | ListQueues | `NextToken` | 50 | `internal/sqs/client.go` |
 
 - Client methods must accept an optional pagination token parameter and return the next token alongside results.
 - Never fetch all pages eagerly on init unless the dataset is known to be small. Load one page, then lazy-load more.
@@ -443,6 +446,26 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 
 **Expanded Parameter Popup**
 - Accessed by pressing `enter` or `space` on a leaf parameter
+- `↑/↓` or `j/k` - Scroll up/down
+- `pgup/pgdn` - Page up/down
+- `esc` - Close popup
+
+### SQS (`internal/ui/sqs/`)
+
+**Queues View (default)**
+- `↑/↓` or `j/k` - Navigate (lazy loads more queues near end)
+- `/` - Search/filter by name
+- `enter` - Peek messages (receives with visibility timeout 0)
+- `space` - Expand queue details in popup
+- `y` - Copy queue URL
+
+**Messages View (after peeking)**
+- `↑/↓` or `j/k` - Navigate messages
+- `enter` or `space` - Expand message in popup (pretty-printed JSON body)
+- `y` - Copy message body
+- `esc/backspace/h` - Go back to queues
+
+**Expanded Popup (queue or message)**
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
 - `esc` - Close popup

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://buymeacoffee.com/sachamama"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" height="36"></a>
 
-sacha is a keyboard-first AWS TUI inspired by classic two-pane file managers. It keeps you in the terminal while you browse, search, and manage AWS resources without bouncing between consoles. Currently supports CloudWatch Logs, S3, DynamoDB, Lambda, and SSM Parameter Store, with an extensible architecture for more AWS services.
+sacha is a keyboard-first AWS TUI inspired by classic two-pane file managers. It keeps you in the terminal while you browse, search, and manage AWS resources without bouncing between consoles. Currently supports CloudWatch Logs, S3, DynamoDB, Lambda, SSM Parameter Store, and SQS, with an extensible architecture for more AWS services.
 
 ## Highlights
 - Two-pane TUI for fast AWS resource exploration.
@@ -11,6 +11,7 @@ sacha is a keyboard-first AWS TUI inspired by classic two-pane file managers. It
 - **DynamoDB**: Browse tables, scan items with lazy loading, view table details and item attributes.
 - **Lambda**: Browse functions, view configuration details, environment variables, and layers.
 - **SSM Parameter Store**: Browse parameters by path hierarchy, view values with decryption, navigate folders.
+- **SQS**: Browse queues, view message counts and attributes, peek messages without consuming them.
 - Remembers your last region/service and plays nicely with AWS profiles.
 - Minimal dependencies; install and run with a single command.
 
@@ -99,7 +100,7 @@ sacha --profile my-aws-profile --region us-east-1
 Global flags:
 - `--profile` – AWS profile to use
 - `--region` – AWS region
-- `--service` – AWS service (`cloudwatch-logs`, `s3`, `dynamodb`, `lambda`, `ssm`)
+- `--service` – AWS service (`cloudwatch-logs`, `s3`, `dynamodb`, `lambda`, `ssm`, `sqs`)
 - `--verbose` – enable debug logging
 - `--version` – show version information
 
@@ -162,6 +163,15 @@ Configuration lives under the OS config directory (e.g. `~/.config/sacha/config.
 - Search/filter parameters with `/`.
 - Lazy loading with pagination for large parameter sets.
 - Supports String, StringList, and SecureString parameter types.
+
+### SQS
+- Browse SQS queues in a two-pane interface with queue attributes in the right panel.
+- View message counts (approximate visible, in-flight, delayed), queue type (FIFO/Standard), visibility timeout, redrive policy.
+- Peek messages with `enter` — uses `ReceiveMessage` with visibility timeout 0 so messages stay in the queue.
+- Navigate peeked messages, view message body (JSON auto-formatted), expand in scrollable popup.
+- Copy queue URL with `y`; copy message body with `y` in message view.
+- Search/filter queues with `/`.
+- Lazy loading with pagination for large queue lists.
 
 ## Keybindings
 
@@ -242,6 +252,21 @@ Configuration lives under the OS config directory (e.g. `~/.config/sacha/config.
 | `↑/↓` or `j/k` | Scroll in expanded view |
 | `pgup/pgdn` | Page scroll in expanded view |
 | `esc/backspace/h` | Go back up one level |
+| `esc` | Close expanded view |
+
+### SQS
+| Key | Action |
+|-----|--------|
+| `↑/↓` or `j/k` | Navigate |
+| `/` | Search/filter |
+| `enter` | Peek messages |
+| `space` | Expand queue details |
+| `y` | Copy queue URL |
+| `enter/space` | Expand message (in messages view) |
+| `y` | Copy message body (in messages view) |
+| `↑/↓` or `j/k` | Scroll in expanded view |
+| `pgup/pgdn` | Page scroll in expanded view |
+| `esc/backspace/h` | Go back to queues (from messages) |
 | `esc` | Close expanded view |
 
 ## Development

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Planned features and new AWS services, building on Sacha's existing TUI patterns.
 
-**Current services:** CloudWatch Logs, S3, DynamoDB, Lambda, SSM Parameter Store
+**Current services:** CloudWatch Logs, S3, DynamoDB, Lambda, SSM Parameter Store, SQS
 
 ---
 
@@ -39,26 +39,27 @@ Browse parameters by path hierarchy with folder-style navigation.
 
 ---
 
-## Phase 3: SQS Queue Browser
+## Phase 3: SQS Queue Browser _(completed)_
 
-Browse queues with message count stats. Peek messages and optionally tail incoming messages.
+Browse queues with message count stats and peek messages.
 
-- Left pane: queue list with approximate message counts (visible, in-flight, delayed)
-- Right pane: queue attributes (type FIFO/Standard, visibility timeout, redrive policy, encryption)
-- `enter` to peek messages (`ReceiveMessage` with visibility timeout 0)
-- `space` to expand queue details in popup
-- `y` to copy queue URL
+- **Queue list** — left pane shows queue names with lazy-load pagination
+- **Queue details** — right pane shows message counts (visible, in-flight, delayed), type (FIFO/Standard), visibility timeout, redrive policy, encryption
+- **Peek messages** — `enter` to peek messages via `ReceiveMessage` with visibility timeout 0 (non-destructive)
+- **Message view** — navigate peeked messages, view body (auto-formatted JSON), expand in popup
+- **Expand queue** — `space` to expand full queue attributes in scrollable popup
+- **Copy** — `y` to copy queue URL; `y` in message view copies message body
+- **Search/filter** — `/` to filter queues by name
 
-### AWS APIs
+### Files
 
-- `ListQueues` — list all queues (paginated via `NextToken`)
-- `GetQueueAttributes` — message counts, configuration
-- `ReceiveMessage` — peek at messages (visibility timeout 0)
-
-### Architecture
-
-- `internal/sqs/client.go` + `internal/sqs/types.go`
-- `internal/ui/sqs/service.go` + `internal/ui/sqs/model.go` + views + messages
+- `internal/sqs/client.go` — `ListQueues`, `GetQueueAttributes`, `PeekMessages`
+- `internal/sqs/types.go` — `Queue`, `QueueAttributes`, `Message` domain types
+- `internal/sqs/client_test.go` — 14 tests covering pagination, attribute parsing, message peeking, error handling
+- `internal/ui/sqs/service.go` — `SQSService` implementing `awsx.Service`
+- `internal/ui/sqs/model.go` — Bubble Tea model with queue list, message peek view, expanded popups
+- `internal/ui/sqs/views.go` — two-pane layout, queue list, details, message list, popup overlays
+- `internal/ui/sqs/messages.go` — `queuesLoadedMsg`, `moreQueuesLoadedMsg`, `queueAttributesMsg`, `messagesLoadedMsg`
 
 ---
 

--- a/cmd/sacha/main.go
+++ b/cmd/sacha/main.go
@@ -14,6 +14,7 @@ import (
 	lambdaui "github.com/sachamama/sacha/internal/ui/lambda"
 	logsui "github.com/sachamama/sacha/internal/ui/logs"
 	s3ui "github.com/sachamama/sacha/internal/ui/s3"
+	sqsui "github.com/sachamama/sacha/internal/ui/sqs"
 	ssmui "github.com/sachamama/sacha/internal/ui/ssm"
 	"github.com/sachamama/sacha/internal/version"
 
@@ -98,6 +99,7 @@ func run(ctx context.Context, flags cliFlags) error {
 		"s3":              s3ui.S3Service{},
 		"dynamodb":        dynamodbui.DynamoDBService{},
 		"lambda":          lambdaui.LambdaService{},
+		"sqs":             sqsui.SQSService{},
 		"ssm":             ssmui.SSMService{},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIM
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 h1:VrhDvQib/i0lxvr3zqlUwLwJP4fpmpyD9wYG1vfSu+Y=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5/go.mod h1:k029+U8SY30/3/ras4G/Fnv/b88N4mAfliNn08Dem4M=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21 h1:Oa0IhwDLVrcBHDlNo1aosG4CxO4HyvzDV5xUWqWcBc0=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21/go.mod h1:t98Ssq+qtXKXl2SFtaSkuT6X42FSM//fnO6sfq5RqGM=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 h1:31Llf5VfrZ78YvYs7sWcS7L2m3waikzRc6q1nYenVS4=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8/go.mod h1:/jgaDlU1UImoxTxhRNxXHvBAPqPZQ8oCjcPbbkR6kac=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 h1:v6EiMvhEYBoHABfbGB4alOYmCIrcgyPPiBE1wZAEbqk=

--- a/internal/sqs/client.go
+++ b/internal/sqs/client.go
@@ -1,0 +1,156 @@
+package sqs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// SQSAPI captures the AWS SDK methods we use.
+type SQSAPI interface {
+	ListQueues(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+	GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
+	ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
+}
+
+const pageSize = 50
+
+// Client wraps the SQS API for queue operations.
+type Client struct {
+	api SQSAPI
+}
+
+// NewClient creates a new SQS client from the provided AWS config.
+func NewClient(cfg aws.Config) *Client {
+	return &Client{
+		api: sqs.NewFromConfig(cfg),
+	}
+}
+
+// ListQueues returns SQS queues with optional pagination.
+func (c *Client) ListQueues(ctx context.Context, token *string) ([]Queue, *string, error) {
+	out, err := c.api.ListQueues(ctx, &sqs.ListQueuesInput{
+		MaxResults: aws.Int32(pageSize),
+		NextToken:  token,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list queues: %w", err)
+	}
+
+	queues := make([]Queue, 0, len(out.QueueUrls))
+	for _, url := range out.QueueUrls {
+		queues = append(queues, Queue{
+			Name: extractQueueName(url),
+			URL:  url,
+		})
+	}
+
+	var nextToken *string
+	if out.NextToken != nil {
+		nextToken = out.NextToken
+	}
+
+	return queues, nextToken, nil
+}
+
+// GetQueueAttributes fetches detailed attributes for a queue.
+func (c *Client) GetQueueAttributes(ctx context.Context, queueURL string) (*QueueAttributes, error) {
+	out, err := c.api.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl: aws.String(queueURL),
+		AttributeNames: []types.QueueAttributeName{
+			types.QueueAttributeNameAll,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get queue attributes: %w", err)
+	}
+
+	attrs := out.Attributes
+	return &QueueAttributes{
+		ARN:                    attrs["QueueArn"],
+		ApproximateMessages:    parseInt64(attrs["ApproximateNumberOfMessages"]),
+		ApproximateNotVisible:  parseInt64(attrs["ApproximateNumberOfMessagesNotVisible"]),
+		ApproximateDelayed:     parseInt64(attrs["ApproximateNumberOfMessagesDelayed"]),
+		CreatedTimestamp:       parseUnixTimestamp(attrs["CreatedTimestamp"]),
+		LastModifiedTimestamp:  parseUnixTimestamp(attrs["LastModifiedTimestamp"]),
+		VisibilityTimeout:      attrs["VisibilityTimeout"],
+		MaxMessageSize:         attrs["MaximumMessageSize"],
+		MessageRetentionPeriod: attrs["MessageRetentionPeriod"],
+		DelaySeconds:           attrs["DelaySeconds"],
+		IsFIFO:                 attrs["FifoQueue"] == "true",
+		ContentDeduplication:   attrs["ContentBasedDeduplication"] == "true",
+		RedrivePolicy:          attrs["RedrivePolicy"],
+		EncryptionType:         attrs["SqsManagedSseEnabled"],
+	}, nil
+}
+
+// PeekMessages receives messages without removing them from the queue.
+// Uses VisibilityTimeout=0 so messages remain available to other consumers.
+func (c *Client) PeekMessages(ctx context.Context, queueURL string, maxMessages int32) ([]Message, error) {
+	out, err := c.api.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: maxMessages,
+		VisibilityTimeout:   0, // Don't hide messages from other consumers
+		AttributeNames: []types.QueueAttributeName{
+			types.QueueAttributeNameAll,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("receive messages: %w", err)
+	}
+
+	messages := make([]Message, 0, len(out.Messages))
+	for _, m := range out.Messages {
+		msg := Message{
+			ID:         aws.ToString(m.MessageId),
+			Body:       aws.ToString(m.Body),
+			MD5:        aws.ToString(m.MD5OfBody),
+			Attributes: make(map[string]string),
+		}
+		for k, v := range m.Attributes {
+			msg.Attributes[k] = v
+		}
+		if ts, ok := m.Attributes["SentTimestamp"]; ok {
+			msg.SentTimestamp = parseMilliTimestamp(ts)
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+// extractQueueName extracts the queue name from its URL.
+func extractQueueName(url string) string {
+	parts := strings.Split(url, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return url
+}
+
+func parseInt64(s string) int64 {
+	v, _ := strconv.ParseInt(s, 10, 64)
+	return v
+}
+
+func parseUnixTimestamp(s string) time.Time {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(v, 0)
+}
+
+func parseMilliTimestamp(s string) time.Time {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.UnixMilli(v)
+}

--- a/internal/sqs/client_test.go
+++ b/internal/sqs/client_test.go
@@ -1,0 +1,395 @@
+package sqs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// mockSQSAPI is a mock implementation of SQSAPI for testing.
+type mockSQSAPI struct {
+	listQueuesFn         func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+	getQueueAttributesFn func(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
+	receiveMessageFn     func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
+}
+
+func (m *mockSQSAPI) ListQueues(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+	if m.listQueuesFn != nil {
+		return m.listQueuesFn(ctx, params, optFns...)
+	}
+	return &sqs.ListQueuesOutput{}, nil
+}
+
+func (m *mockSQSAPI) GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	if m.getQueueAttributesFn != nil {
+		return m.getQueueAttributesFn(ctx, params, optFns...)
+	}
+	return &sqs.GetQueueAttributesOutput{}, nil
+}
+
+func (m *mockSQSAPI) ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+	if m.receiveMessageFn != nil {
+		return m.receiveMessageFn(ctx, params, optFns...)
+	}
+	return &sqs.ReceiveMessageOutput{}, nil
+}
+
+func TestListQueues(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     *string
+		mockFn    func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+		wantCount int
+		wantToken bool
+		wantErr   bool
+	}{
+		{
+			name: "empty response",
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				return &sqs.ListQueuesOutput{}, nil
+			},
+			wantCount: 0,
+		},
+		{
+			name: "returns queues with names extracted",
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				return &sqs.ListQueuesOutput{
+					QueueUrls: []string{
+						"https://sqs.us-east-1.amazonaws.com/123456789/my-queue",
+						"https://sqs.us-east-1.amazonaws.com/123456789/other-queue.fifo",
+					},
+				}, nil
+			},
+			wantCount: 2,
+		},
+		{
+			name: "pagination with token",
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				return &sqs.ListQueuesOutput{
+					QueueUrls: []string{
+						"https://sqs.us-east-1.amazonaws.com/123456789/queue1",
+					},
+					NextToken: aws.String("next-page"),
+				}, nil
+			},
+			wantCount: 1,
+			wantToken: true,
+		},
+		{
+			name:  "passes continuation token",
+			token: aws.String("continue-here"),
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				if params.NextToken == nil || *params.NextToken != "continue-here" {
+					t.Errorf("expected token 'continue-here', got %v", params.NextToken)
+				}
+				return &sqs.ListQueuesOutput{}, nil
+			},
+			wantCount: 0,
+		},
+		{
+			name: "uses page size",
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				if params.MaxResults == nil || *params.MaxResults != pageSize {
+					t.Errorf("expected MaxResults %d, got %v", pageSize, params.MaxResults)
+				}
+				return &sqs.ListQueuesOutput{}, nil
+			},
+			wantCount: 0,
+		},
+		{
+			name: "API error",
+			mockFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+				return nil, errors.New("access denied")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{api: &mockSQSAPI{listQueuesFn: tt.mockFn}}
+
+			queues, nextToken, err := client.ListQueues(context.Background(), tt.token)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ListQueues() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if len(queues) != tt.wantCount {
+				t.Fatalf("got %d queues, want %d", len(queues), tt.wantCount)
+			}
+
+			if (nextToken != nil) != tt.wantToken {
+				t.Errorf("nextToken = %v, wantToken = %v", nextToken, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestListQueues_ExtractsNames(t *testing.T) {
+	client := &Client{api: &mockSQSAPI{
+		listQueuesFn: func(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+			return &sqs.ListQueuesOutput{
+				QueueUrls: []string{
+					"https://sqs.us-east-1.amazonaws.com/123456789/my-queue",
+					"https://sqs.us-east-1.amazonaws.com/123456789/orders.fifo",
+				},
+			}, nil
+		},
+	}}
+
+	queues, _, err := client.ListQueues(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if queues[0].Name != "my-queue" {
+		t.Errorf("queue[0].Name = %q, want %q", queues[0].Name, "my-queue")
+	}
+	if queues[0].URL != "https://sqs.us-east-1.amazonaws.com/123456789/my-queue" {
+		t.Errorf("queue[0].URL = %q, unexpected", queues[0].URL)
+	}
+	if queues[1].Name != "orders.fifo" {
+		t.Errorf("queue[1].Name = %q, want %q", queues[1].Name, "orders.fifo")
+	}
+}
+
+func TestGetQueueAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		mockFn  func(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
+		wantErr bool
+	}{
+		{
+			name: "returns all attributes",
+			mockFn: func(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+				if *params.QueueUrl != "https://sqs.us-east-1.amazonaws.com/123/test-queue" {
+					t.Errorf("unexpected queue URL: %s", *params.QueueUrl)
+				}
+				// Verify we request All attributes
+				found := false
+				for _, attr := range params.AttributeNames {
+					if attr == types.QueueAttributeNameAll {
+						found = true
+					}
+				}
+				if !found {
+					t.Error("expected QueueAttributeNameAll in request")
+				}
+				return &sqs.GetQueueAttributesOutput{
+					Attributes: map[string]string{
+						"QueueArn":                              "arn:aws:sqs:us-east-1:123:test-queue",
+						"ApproximateNumberOfMessages":           "42",
+						"ApproximateNumberOfMessagesNotVisible": "5",
+						"ApproximateNumberOfMessagesDelayed":    "3",
+						"CreatedTimestamp":                      "1700000000",
+						"LastModifiedTimestamp":                 "1700001000",
+						"VisibilityTimeout":                     "30",
+						"MaximumMessageSize":                    "262144",
+						"MessageRetentionPeriod":                "345600",
+						"DelaySeconds":                          "0",
+						"FifoQueue":                             "true",
+						"ContentBasedDeduplication":             "true",
+						"RedrivePolicy":                         `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123:dlq","maxReceiveCount":3}`,
+						"SqsManagedSseEnabled":                  "true",
+					},
+				}, nil
+			},
+		},
+		{
+			name: "API error",
+			mockFn: func(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+				return nil, errors.New("queue not found")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{api: &mockSQSAPI{getQueueAttributesFn: tt.mockFn}}
+
+			attrs, err := client.GetQueueAttributes(context.Background(), "https://sqs.us-east-1.amazonaws.com/123/test-queue")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetQueueAttributes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if attrs.ARN != "arn:aws:sqs:us-east-1:123:test-queue" {
+				t.Errorf("ARN = %q", attrs.ARN)
+			}
+			if attrs.ApproximateMessages != 42 {
+				t.Errorf("ApproximateMessages = %d, want 42", attrs.ApproximateMessages)
+			}
+			if attrs.ApproximateNotVisible != 5 {
+				t.Errorf("ApproximateNotVisible = %d, want 5", attrs.ApproximateNotVisible)
+			}
+			if attrs.ApproximateDelayed != 3 {
+				t.Errorf("ApproximateDelayed = %d, want 3", attrs.ApproximateDelayed)
+			}
+			if !attrs.IsFIFO {
+				t.Error("expected IsFIFO = true")
+			}
+			if !attrs.ContentDeduplication {
+				t.Error("expected ContentDeduplication = true")
+			}
+			if attrs.VisibilityTimeout != "30" {
+				t.Errorf("VisibilityTimeout = %q, want '30'", attrs.VisibilityTimeout)
+			}
+			if attrs.RedrivePolicy == "" {
+				t.Error("expected RedrivePolicy to be set")
+			}
+		})
+	}
+}
+
+func TestPeekMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockFn    func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "empty queue",
+			mockFn: func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+				return &sqs.ReceiveMessageOutput{}, nil
+			},
+			wantCount: 0,
+		},
+		{
+			name: "returns messages with visibility timeout 0",
+			mockFn: func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+				if params.VisibilityTimeout != 0 {
+					t.Errorf("expected VisibilityTimeout 0, got %d", params.VisibilityTimeout)
+				}
+				if params.MaxNumberOfMessages != 10 {
+					t.Errorf("expected MaxNumberOfMessages 10, got %d", params.MaxNumberOfMessages)
+				}
+				return &sqs.ReceiveMessageOutput{
+					Messages: []types.Message{
+						{
+							MessageId: aws.String("msg-1"),
+							Body:      aws.String(`{"event":"order_created"}`),
+							MD5OfBody: aws.String("abc123"),
+							Attributes: map[string]string{
+								"SentTimestamp":           "1700000000000",
+								"ApproximateReceiveCount": "1",
+							},
+						},
+						{
+							MessageId: aws.String("msg-2"),
+							Body:      aws.String("plain text message"),
+							MD5OfBody: aws.String("def456"),
+							Attributes: map[string]string{
+								"SentTimestamp": "1700000001000",
+							},
+						},
+					},
+				}, nil
+			},
+			wantCount: 2,
+		},
+		{
+			name: "API error",
+			mockFn: func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+				return nil, errors.New("access denied")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{api: &mockSQSAPI{receiveMessageFn: tt.mockFn}}
+
+			messages, err := client.PeekMessages(context.Background(), "https://sqs.us-east-1.amazonaws.com/123/test-queue", 10)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("PeekMessages() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if len(messages) != tt.wantCount {
+				t.Fatalf("got %d messages, want %d", len(messages), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestPeekMessages_ParsesFields(t *testing.T) {
+	client := &Client{api: &mockSQSAPI{
+		receiveMessageFn: func(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+			return &sqs.ReceiveMessageOutput{
+				Messages: []types.Message{
+					{
+						MessageId: aws.String("msg-abc"),
+						Body:      aws.String(`{"key":"value"}`),
+						MD5OfBody: aws.String("md5hash"),
+						Attributes: map[string]string{
+							"SentTimestamp": "1700000000000",
+						},
+					},
+				},
+			}, nil
+		},
+	}}
+
+	messages, err := client.PeekMessages(context.Background(), "https://sqs.us-east-1.amazonaws.com/123/q", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := messages[0]
+	if msg.ID != "msg-abc" {
+		t.Errorf("ID = %q, want 'msg-abc'", msg.ID)
+	}
+	if msg.Body != `{"key":"value"}` {
+		t.Errorf("Body = %q", msg.Body)
+	}
+	if msg.MD5 != "md5hash" {
+		t.Errorf("MD5 = %q", msg.MD5)
+	}
+	if msg.SentTimestamp.IsZero() {
+		t.Error("SentTimestamp should not be zero")
+	}
+	if msg.Attributes["SentTimestamp"] != "1700000000000" {
+		t.Errorf("Attributes[SentTimestamp] = %q", msg.Attributes["SentTimestamp"])
+	}
+}
+
+func TestExtractQueueName(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://sqs.us-east-1.amazonaws.com/123456789/my-queue", "my-queue"},
+		{"https://sqs.us-east-1.amazonaws.com/123456789/orders.fifo", "orders.fifo"},
+		{"my-queue", "my-queue"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			got := extractQueueName(tt.url)
+			if got != tt.want {
+				t.Errorf("extractQueueName(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sqs/types.go
+++ b/internal/sqs/types.go
@@ -1,0 +1,36 @@
+package sqs
+
+import "time"
+
+// Queue represents an SQS queue.
+type Queue struct {
+	Name string
+	URL  string
+}
+
+// QueueAttributes contains detailed attributes for an SQS queue.
+type QueueAttributes struct {
+	ARN                    string
+	ApproximateMessages    int64
+	ApproximateNotVisible  int64
+	ApproximateDelayed     int64
+	CreatedTimestamp       time.Time
+	LastModifiedTimestamp  time.Time
+	VisibilityTimeout      string
+	MaxMessageSize         string
+	MessageRetentionPeriod string
+	DelaySeconds           string
+	IsFIFO                 bool
+	ContentDeduplication   bool
+	RedrivePolicy          string
+	EncryptionType         string
+}
+
+// Message represents an SQS message from a peek operation.
+type Message struct {
+	ID            string
+	Body          string
+	MD5           string
+	SentTimestamp time.Time
+	Attributes    map[string]string
+}

--- a/internal/ui/sqs/messages.go
+++ b/internal/ui/sqs/messages.go
@@ -1,0 +1,30 @@
+package sqs
+
+import "github.com/sachamama/sacha/internal/sqs"
+
+// queuesLoadedMsg is sent when the initial queue listing completes.
+type queuesLoadedMsg struct {
+	queues    []sqs.Queue
+	nextToken *string
+	err       error
+}
+
+// moreQueuesLoadedMsg is sent when additional queues are loaded (lazy loading).
+type moreQueuesLoadedMsg struct {
+	queues    []sqs.Queue
+	nextToken *string
+	err       error
+}
+
+// queueAttributesMsg is sent when a queue's attributes are fetched.
+type queueAttributesMsg struct {
+	attrs *sqs.QueueAttributes
+	url   string // URL to match against current cursor
+	err   error
+}
+
+// messagesLoadedMsg is sent when peek messages completes.
+type messagesLoadedMsg struct {
+	messages []sqs.Message
+	err      error
+}

--- a/internal/ui/sqs/model.go
+++ b/internal/ui/sqs/model.go
@@ -1,0 +1,544 @@
+package sqs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachamama/sacha/internal/sqs"
+)
+
+// Model is the Bubble Tea model for the SQS Queue Browser.
+type Model struct {
+	client *sqs.Client
+
+	// List state
+	queues     []sqs.Queue
+	cursor     int
+	listOffset int
+
+	// Pagination
+	nextToken   *string
+	loadingMore bool
+
+	// Right pane - queue attributes
+	attrs *sqs.QueueAttributes
+
+	// Message peek
+	messages        []sqs.Message
+	viewingMessages bool
+	messageCursor   int
+	messageOffset   int
+
+	// Expanded popup
+	expandedQueue   int            // index of expanded queue, -1 if none
+	expandedView    viewport.Model // viewport for scrolling expanded content
+	expandedMessage int            // index of expanded message, -1 if none
+
+	// UI
+	width      int
+	height     int
+	searching  bool
+	search     textinput.Model
+	loading    bool
+	statusLine string
+}
+
+// NewModel creates a new SQS browser model.
+func NewModel(client *sqs.Client) Model {
+	ti := textinput.New()
+	ti.Placeholder = "filter"
+	ti.Prompt = "/ "
+	return Model{
+		client:          client,
+		search:          ti,
+		loading:         true,
+		expandedQueue:   -1,
+		expandedMessage: -1,
+	}
+}
+
+// Init initializes the model by loading queues.
+func (m Model) Init() tea.Cmd {
+	return m.loadQueuesCmd()
+}
+
+// Update handles messages and user input.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case queuesLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.statusLine = msg.err.Error()
+			return m, nil
+		}
+		m.queues = msg.queues
+		m.nextToken = msg.nextToken
+		m.cursor = 0
+		m.attrs = nil
+		if m.nextToken != nil {
+			m.statusLine = fmt.Sprintf("Loaded %d queues (more available)", len(msg.queues))
+		} else {
+			m.statusLine = fmt.Sprintf("Loaded %d queues", len(msg.queues))
+		}
+		return m, m.fetchAttributesCmd()
+
+	case moreQueuesLoadedMsg:
+		m.loadingMore = false
+		if msg.err != nil {
+			m.statusLine = msg.err.Error()
+			return m, nil
+		}
+		m.queues = append(m.queues, msg.queues...)
+		m.nextToken = msg.nextToken
+		if m.nextToken != nil {
+			m.statusLine = fmt.Sprintf("Loaded %d queues (more available)", len(m.queues))
+		} else {
+			m.statusLine = fmt.Sprintf("Loaded %d queues", len(m.queues))
+		}
+		return m, m.loadMoreIfNeeded()
+
+	case queueAttributesMsg:
+		if msg.err != nil {
+			return m, nil
+		}
+		if m.currentQueueURL() == msg.url {
+			m.attrs = msg.attrs
+		}
+		return m, nil
+
+	case messagesLoadedMsg:
+		if msg.err != nil {
+			m.statusLine = msg.err.Error()
+			return m, nil
+		}
+		m.messages = msg.messages
+		m.viewingMessages = true
+		m.messageCursor = 0
+		m.messageOffset = 0
+		if len(msg.messages) == 0 {
+			m.statusLine = "No messages in queue"
+		} else {
+			m.statusLine = fmt.Sprintf("Peeked %d messages", len(msg.messages))
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKeyMsg(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Handle search input
+	if m.searching {
+		switch msg.Type {
+		case tea.KeyEnter, tea.KeyEscape:
+			m.searching = false
+			m.clampCursor()
+			return m, tea.Batch(m.onCursorMove(), m.loadMoreIfNeeded())
+		}
+		var cmd tea.Cmd
+		m.search, cmd = m.search.Update(msg)
+		m.clampCursor()
+		return m, cmd
+	}
+
+	// Handle expanded message popup
+	if m.expandedMessage >= 0 {
+		switch msg.String() {
+		case "up", "k":
+			m.expandedView.ScrollUp(1)
+			return m, nil
+		case "down", "j":
+			m.expandedView.ScrollDown(1)
+			return m, nil
+		case "pgup":
+			m.expandedView.PageUp()
+			return m, nil
+		case "pgdn":
+			m.expandedView.PageDown()
+			return m, nil
+		case "esc", "q":
+			m.expandedMessage = -1
+			return m, nil
+		}
+		return m, nil
+	}
+
+	// Handle expanded queue popup
+	if m.expandedQueue >= 0 {
+		switch msg.String() {
+		case "up", "k":
+			m.expandedView.ScrollUp(1)
+			return m, nil
+		case "down", "j":
+			m.expandedView.ScrollDown(1)
+			return m, nil
+		case "pgup":
+			m.expandedView.PageUp()
+			return m, nil
+		case "pgdn":
+			m.expandedView.PageDown()
+			return m, nil
+		case "esc", "q":
+			m.expandedQueue = -1
+			return m, nil
+		}
+		return m, nil
+	}
+
+	// Handle message view navigation
+	if m.viewingMessages {
+		switch msg.String() {
+		case "up", "k":
+			if m.messageCursor > 0 {
+				m.messageCursor--
+				m.ensureMessageCursorVisible()
+			}
+			return m, nil
+		case "down", "j":
+			if m.messageCursor < len(m.messages)-1 {
+				m.messageCursor++
+				m.ensureMessageCursorVisible()
+			}
+			return m, nil
+		case "enter", " ":
+			if len(m.messages) > 0 && m.messageCursor < len(m.messages) {
+				m.expandedMessage = m.messageCursor
+				content := m.renderExpandedMessageContent(m.messages[m.messageCursor])
+				m.expandedView = viewport.New(m.expandedWidth(), m.expandedHeight())
+				m.expandedView.SetContent(content)
+			}
+			return m, nil
+		case "esc", "backspace", "h":
+			m.viewingMessages = false
+			m.messages = nil
+			m.messageCursor = 0
+			m.messageOffset = 0
+			m.statusLine = ""
+			return m, nil
+		case "y":
+			if len(m.messages) > 0 && m.messageCursor < len(m.messages) {
+				text := m.messages[m.messageCursor].Body
+				_ = clipboard.WriteAll(text)
+				m.statusLine = "Copied message body"
+			}
+			return m, nil
+		}
+		return m, nil
+	}
+
+	// Normal queue list navigation
+	switch msg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+			m.ensureCursorVisible()
+			return m, m.onCursorMove()
+		}
+	case "down", "j":
+		maxIdx := m.maxCursorIndex()
+		if m.cursor < maxIdx {
+			m.cursor++
+			m.ensureCursorVisible()
+			cmd := m.onCursorMove()
+			// Lazy load more when near the end
+			if m.nextToken != nil && !m.loadingMore {
+				if m.cursor >= len(m.filteredQueues())-5 {
+					m.loadingMore = true
+					return m, tea.Batch(cmd, m.loadMoreCmd())
+				}
+			}
+			return m, cmd
+		}
+	case "enter":
+		return m.handlePeek()
+	case " ":
+		return m.handleExpand()
+	case "/":
+		m.searching = true
+		m.search.SetValue("")
+		return m, m.search.Focus()
+	case "y":
+		text := m.getCopyText()
+		if text != "" {
+			_ = clipboard.WriteAll(text)
+			m.statusLine = "Copied: " + text
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) handlePeek() (tea.Model, tea.Cmd) {
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		return m, nil
+	}
+	queue := items[m.cursor]
+	m.statusLine = "Peeking messages..."
+	return m, m.peekMessagesCmd(queue.URL)
+}
+
+func (m Model) handleExpand() (tea.Model, tea.Cmd) {
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		return m, nil
+	}
+	m.expandedQueue = m.cursor
+	content := m.renderExpandedQueueContent()
+	m.expandedView = viewport.New(m.expandedWidth(), m.expandedHeight())
+	m.expandedView.SetContent(content)
+	return m, nil
+}
+
+// View renders the model.
+func (m Model) View() string {
+	if m.width == 0 {
+		return "Loading..."
+	}
+
+	// Split width for two panels
+	leftWidth := m.width / 2
+	rightWidth := m.width - leftWidth
+	bodyHeight := m.bodyHeight()
+
+	left := panelStyle.Width(leftWidth - 2).Height(bodyHeight).Render(m.renderLeft())
+	right := panelStyle.Width(rightWidth - 2).Height(bodyHeight).Render(m.renderRight())
+
+	view := joinHorizontal(left, right)
+
+	// Overlay expanded popups if active
+	if m.expandedMessage >= 0 {
+		view = m.renderExpandedPopup(view, "Message: "+m.messages[m.expandedMessage].ID)
+	} else if m.expandedQueue >= 0 {
+		items := m.filteredQueues()
+		if m.expandedQueue < len(items) {
+			view = m.renderExpandedPopup(view, "Queue: "+items[m.expandedQueue].Name)
+		}
+	}
+
+	return view
+}
+
+func (m Model) bodyHeight() int {
+	h := m.height - 4
+	if h < 4 {
+		return m.height
+	}
+	return h
+}
+
+func (m Model) listHeight() int {
+	// bodyHeight minus: header(1) + search hint(1) + blank(1) + footer(1) + status(1) + borders(2)
+	h := m.bodyHeight() - 7
+	if h < 3 {
+		return 3
+	}
+	return h
+}
+
+func (m *Model) ensureCursorVisible() {
+	visibleHeight := m.listHeight()
+	if visibleHeight <= 0 {
+		return
+	}
+
+	if m.cursor < m.listOffset {
+		m.listOffset = m.cursor
+	}
+
+	effective := visibleHeight
+	if m.listOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
+	if m.cursor >= m.listOffset+effective {
+		m.listOffset = m.cursor - effective + 1
+	}
+
+	if m.listOffset < 0 {
+		m.listOffset = 0
+	}
+}
+
+func (m *Model) ensureMessageCursorVisible() {
+	visibleHeight := m.listHeight()
+	if visibleHeight <= 0 {
+		return
+	}
+
+	if m.messageCursor < m.messageOffset {
+		m.messageOffset = m.messageCursor
+	}
+
+	effective := visibleHeight
+	if m.messageOffset > 0 {
+		effective--
+	}
+	if effective < 1 {
+		effective = 1
+	}
+
+	if m.messageCursor >= m.messageOffset+effective {
+		m.messageOffset = m.messageCursor - effective + 1
+	}
+
+	if m.messageOffset < 0 {
+		m.messageOffset = 0
+	}
+}
+
+func (m Model) maxCursorIndex() int {
+	return len(m.filteredQueues()) - 1
+}
+
+func (m *Model) clampCursor() {
+	maxIdx := m.maxCursorIndex()
+	if m.cursor > maxIdx {
+		m.cursor = maxIdx
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	m.ensureCursorVisible()
+}
+
+func (m Model) currentQueueURL() string {
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		return ""
+	}
+	return items[m.cursor].URL
+}
+
+func (m Model) onCursorMove() tea.Cmd {
+	m.attrs = nil
+	return m.fetchAttributesCmd()
+}
+
+func (m Model) getCopyText() string {
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		return ""
+	}
+	return items[m.cursor].URL
+}
+
+func (m Model) filteredQueues() []sqs.Queue {
+	if m.search.Value() == "" {
+		return m.queues
+	}
+	q := strings.ToLower(m.search.Value())
+	out := make([]sqs.Queue, 0, len(m.queues))
+	for _, queue := range m.queues {
+		if strings.Contains(strings.ToLower(queue.Name), q) {
+			out = append(out, queue)
+		}
+	}
+	return out
+}
+
+// loadMoreIfNeeded loads the next page if a filter is active and the filtered
+// results don't fill the visible list height.
+func (m *Model) loadMoreIfNeeded() tea.Cmd {
+	if m.search.Value() == "" {
+		return nil
+	}
+	if m.nextToken == nil || m.loadingMore {
+		return nil
+	}
+	if len(m.filteredQueues()) >= m.listHeight() {
+		return nil
+	}
+	m.loadingMore = true
+	return m.loadMoreCmd()
+}
+
+// Commands
+
+func (m Model) loadQueuesCmd() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		queues, nextToken, err := m.client.ListQueues(ctx, nil)
+		return queuesLoadedMsg{queues: queues, nextToken: nextToken, err: err}
+	}
+}
+
+func (m Model) loadMoreCmd() tea.Cmd {
+	token := m.nextToken
+	return func() tea.Msg {
+		ctx := context.Background()
+		queues, nextToken, err := m.client.ListQueues(ctx, token)
+		return moreQueuesLoadedMsg{queues: queues, nextToken: nextToken, err: err}
+	}
+}
+
+func (m Model) fetchAttributesCmd() tea.Cmd {
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		return nil
+	}
+	url := items[m.cursor].URL
+	return func() tea.Msg {
+		ctx := context.Background()
+		attrs, err := m.client.GetQueueAttributes(ctx, url)
+		return queueAttributesMsg{attrs: attrs, url: url, err: err}
+	}
+}
+
+func (m Model) peekMessagesCmd(queueURL string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		messages, err := m.client.PeekMessages(ctx, queueURL, 10)
+		return messagesLoadedMsg{messages: messages, err: err}
+	}
+}
+
+func (m Model) expandedWidth() int {
+	w := m.width - 8
+	if w < 40 {
+		return 40
+	}
+	return w
+}
+
+func (m Model) expandedHeight() int {
+	h := m.height - 10
+	if h < 10 {
+		return 10
+	}
+	return h
+}
+
+// Searching reports whether the model has an active text input.
+func (m Model) Searching() bool {
+	return m.searching
+}
+
+// StatusHelp returns context-aware help text for the status bar.
+func (m Model) StatusHelp() string {
+	if m.searching {
+		return "enter/esc close search"
+	}
+	if m.expandedMessage >= 0 || m.expandedQueue >= 0 {
+		return "↑↓ scroll, esc close"
+	}
+	if m.viewingMessages {
+		return "↑↓ move, enter expand, y copy body, esc back"
+	}
+	return "↑↓ move, / search, enter peek, space expand, y copy URL"
+}

--- a/internal/ui/sqs/service.go
+++ b/internal/ui/sqs/service.go
@@ -1,0 +1,30 @@
+package sqs
+
+import (
+	"context"
+
+	sdkaws "github.com/aws/aws-sdk-go-v2/aws"
+	tea "github.com/charmbracelet/bubbletea"
+	awsx "github.com/sachamama/sacha/internal/aws"
+	"github.com/sachamama/sacha/internal/sqs"
+)
+
+// SQSService wires the SQS Queue Browser UI to the service registry.
+type SQSService struct{}
+
+// Name returns the service identifier.
+func (SQSService) Name() string {
+	return "sqs"
+}
+
+// Title returns the display name for the service.
+func (SQSService) Title() string {
+	return "SQS Queues"
+}
+
+// Init initializes the SQS browser model.
+func (SQSService) Init(ctx context.Context, cfg sdkaws.Config, opts awsx.ServiceOptions) (tea.Model, error) {
+	client := sqs.NewClient(cfg)
+	model := NewModel(client)
+	return model, nil
+}

--- a/internal/ui/sqs/views.go
+++ b/internal/ui/sqs/views.go
@@ -1,0 +1,397 @@
+package sqs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sachamama/sacha/internal/sqs"
+)
+
+var (
+	panelStyle = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			Padding(0, 1)
+
+	titleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("213")).
+			Bold(true)
+
+	cursorStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("229")).
+			Background(lipgloss.Color("57"))
+
+	dimText = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("33"))
+
+	statusStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("44"))
+
+	fifoStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214"))
+
+	countStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("156"))
+
+	popupBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("213")).
+				Padding(1, 2)
+)
+
+func joinHorizontal(left, right string) string {
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+}
+
+func (m Model) renderLeft() string {
+	b := &strings.Builder{}
+
+	if m.viewingMessages {
+		return m.renderMessageList(b)
+	}
+
+	// Header
+	fmt.Fprintln(b, titleStyle.Render("SQS Queues"))
+
+	if m.loading {
+		fmt.Fprintln(b, dimText.Render("Loading..."))
+		return b.String()
+	}
+
+	// Search input
+	if m.searching {
+		fmt.Fprintln(b, m.search.View())
+	} else if m.search.Value() != "" {
+		fmt.Fprintln(b, statusStyle.Render(fmt.Sprintf("Filter: %s", m.search.Value())))
+	} else {
+		fmt.Fprintln(b, dimText.Render("Press / to filter"))
+	}
+
+	visibleHeight := m.listHeight()
+
+	// List items
+	m.renderQueueList(b, visibleHeight)
+
+	// Status footer
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s\n", dimText.Render(fmt.Sprintf("Total: %d queues", len(m.filteredQueues()))))
+
+	if m.statusLine != "" {
+		fmt.Fprintf(b, "%s\n", statusStyle.Render(m.statusLine))
+	}
+
+	return b.String()
+}
+
+func (m Model) renderQueueList(b *strings.Builder, visibleHeight int) {
+	items := m.filteredQueues()
+	if len(items) == 0 {
+		fmt.Fprintln(b, dimText.Render("No queues found"))
+		return
+	}
+
+	// Show scroll indicator if needed
+	if m.listOffset > 0 {
+		fmt.Fprintln(b, dimText.Render("  ↑ more above"))
+		visibleHeight--
+	}
+
+	endIdx := min(m.listOffset+visibleHeight, len(items))
+
+	for i := m.listOffset; i < endIdx; i++ {
+		item := items[i]
+		line := fmt.Sprintf("  %s", item.Name)
+
+		if i == m.cursor {
+			line = cursorStyle.Render(line)
+		}
+		fmt.Fprintln(b, line)
+	}
+
+	if endIdx < len(items) {
+		if m.loadingMore {
+			fmt.Fprintln(b, dimText.Render("  ⟳ loading more..."))
+		} else {
+			fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+		}
+	}
+}
+
+func (m Model) renderMessageList(b *strings.Builder) string {
+	fmt.Fprintln(b, titleStyle.Render("Messages"))
+
+	if len(m.messages) == 0 {
+		fmt.Fprintln(b, dimText.Render("No messages"))
+		return b.String()
+	}
+
+	visibleHeight := m.listHeight()
+
+	// Show scroll indicator if needed
+	if m.messageOffset > 0 {
+		fmt.Fprintln(b, dimText.Render("  ↑ more above"))
+		visibleHeight--
+	}
+
+	endIdx := min(m.messageOffset+visibleHeight, len(m.messages))
+
+	for i := m.messageOffset; i < endIdx; i++ {
+		msg := m.messages[i]
+		// Show a truncated preview of the body
+		preview := truncate(msg.Body, 50)
+		line := fmt.Sprintf("  %s  %s", dimText.Render(msg.ID[:minInt(8, len(msg.ID))]), preview)
+
+		if i == m.messageCursor {
+			line = cursorStyle.Render(line)
+		}
+		fmt.Fprintln(b, line)
+	}
+
+	if endIdx < len(m.messages) {
+		fmt.Fprintln(b, dimText.Render("  ↓ more below"))
+	}
+
+	// Status
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s\n", dimText.Render(fmt.Sprintf("%d messages", len(m.messages))))
+
+	if m.statusLine != "" {
+		fmt.Fprintf(b, "%s\n", statusStyle.Render(m.statusLine))
+	}
+
+	return b.String()
+}
+
+func (m Model) renderRight() string {
+	b := &strings.Builder{}
+
+	if m.viewingMessages {
+		return m.renderMessageDetails(b)
+	}
+
+	fmt.Fprintln(b, titleStyle.Render("Queue Details"))
+
+	items := m.filteredQueues()
+	if len(items) == 0 || m.cursor >= len(items) {
+		fmt.Fprintln(b, dimText.Render("No queue selected"))
+		return b.String()
+	}
+
+	item := items[m.cursor]
+
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), item.Name)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("URL:"), dimText.Render(item.URL))
+
+	if m.attrs != nil {
+		fmt.Fprintln(b)
+		// Message counts
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Messages:"), countStyle.Render(fmt.Sprintf("%d", m.attrs.ApproximateMessages)))
+		fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("In-Flight:"), m.attrs.ApproximateNotVisible)
+		fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("Delayed:"), m.attrs.ApproximateDelayed)
+
+		fmt.Fprintln(b)
+		// Queue type
+		if m.attrs.IsFIFO {
+			fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Type:"), fifoStyle.Render("FIFO"))
+		} else {
+			fmt.Fprintf(b, "%s  Standard\n", labelStyle.Render("Type:"))
+		}
+
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Visibility:"), m.attrs.VisibilityTimeout)
+		fmt.Fprintf(b, "%s  %s bytes\n", labelStyle.Render("Max Size:"), m.attrs.MaxMessageSize)
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Retention:"), m.attrs.MessageRetentionPeriod)
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Delay:"), m.attrs.DelaySeconds)
+
+		if m.attrs.RedrivePolicy != "" {
+			fmt.Fprintln(b)
+			fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Redrive:"), m.attrs.RedrivePolicy)
+		}
+
+		if m.attrs.ARN != "" {
+			fmt.Fprintln(b)
+			fmt.Fprintf(b, "%s\n", labelStyle.Render("ARN:"))
+			fmt.Fprintf(b, "%s\n", dimText.Render(m.attrs.ARN))
+		}
+	} else {
+		fmt.Fprintln(b, dimText.Render("Loading attributes..."))
+	}
+
+	return b.String()
+}
+
+func (m Model) renderMessageDetails(b *strings.Builder) string {
+	fmt.Fprintln(b, titleStyle.Render("Message Details"))
+
+	if len(m.messages) == 0 || m.messageCursor >= len(m.messages) {
+		fmt.Fprintln(b, dimText.Render("No message selected"))
+		return b.String()
+	}
+
+	msg := m.messages[m.messageCursor]
+
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("ID:"), msg.ID)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("MD5:"), dimText.Render(msg.MD5))
+
+	if !msg.SentTimestamp.IsZero() {
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Sent:"), msg.SentTimestamp.Format("2006-01-02 15:04:05"))
+	}
+
+	if count, ok := msg.Attributes["ApproximateReceiveCount"]; ok {
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Receives:"), count)
+	}
+
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s\n", labelStyle.Render("Body:"))
+	// Try to pretty-print JSON
+	body := msg.Body
+	var jsonObj interface{}
+	if err := json.Unmarshal([]byte(body), &jsonObj); err == nil {
+		if pretty, err := json.MarshalIndent(jsonObj, "", "  "); err == nil {
+			body = string(pretty)
+		}
+	}
+	fmt.Fprintln(b, body)
+
+	return b.String()
+}
+
+func (m Model) renderExpandedQueueContent() string {
+	b := &strings.Builder{}
+
+	items := m.filteredQueues()
+	if m.expandedQueue >= len(items) {
+		return ""
+	}
+
+	item := items[m.expandedQueue]
+
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), item.Name)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("URL:"), item.URL)
+
+	if m.attrs != nil {
+		fmt.Fprintln(b)
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("ARN:"), m.attrs.ARN)
+		fmt.Fprintln(b)
+		fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("Messages:"), m.attrs.ApproximateMessages)
+		fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("In-Flight:"), m.attrs.ApproximateNotVisible)
+		fmt.Fprintf(b, "%s  %d\n", labelStyle.Render("Delayed:"), m.attrs.ApproximateDelayed)
+		fmt.Fprintln(b)
+		if m.attrs.IsFIFO {
+			fmt.Fprintf(b, "%s  FIFO\n", labelStyle.Render("Type:"))
+			fmt.Fprintf(b, "%s  %v\n", labelStyle.Render("Content Dedup:"), m.attrs.ContentDeduplication)
+		} else {
+			fmt.Fprintf(b, "%s  Standard\n", labelStyle.Render("Type:"))
+		}
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Visibility Timeout:"), m.attrs.VisibilityTimeout)
+		fmt.Fprintf(b, "%s  %s bytes\n", labelStyle.Render("Max Message Size:"), m.attrs.MaxMessageSize)
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Retention Period:"), m.attrs.MessageRetentionPeriod)
+		fmt.Fprintf(b, "%s  %ss\n", labelStyle.Render("Delay Seconds:"), m.attrs.DelaySeconds)
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Encryption:"), m.attrs.EncryptionType)
+
+		if !m.attrs.CreatedTimestamp.IsZero() {
+			fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Created:"), m.attrs.CreatedTimestamp.Format("2006-01-02 15:04:05"))
+		}
+		if !m.attrs.LastModifiedTimestamp.IsZero() {
+			fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Modified:"), m.attrs.LastModifiedTimestamp.Format("2006-01-02 15:04:05"))
+		}
+
+		if m.attrs.RedrivePolicy != "" {
+			fmt.Fprintln(b)
+			fmt.Fprintf(b, "%s\n", labelStyle.Render("Redrive Policy:"))
+			// Pretty-print JSON redrive policy
+			var jsonObj interface{}
+			if err := json.Unmarshal([]byte(m.attrs.RedrivePolicy), &jsonObj); err == nil {
+				if pretty, err := json.MarshalIndent(jsonObj, "", "  "); err == nil {
+					fmt.Fprintln(b, string(pretty))
+				} else {
+					fmt.Fprintln(b, m.attrs.RedrivePolicy)
+				}
+			} else {
+				fmt.Fprintln(b, m.attrs.RedrivePolicy)
+			}
+		}
+	} else {
+		fmt.Fprintln(b)
+		fmt.Fprintln(b, dimText.Render("Loading attributes..."))
+	}
+
+	return b.String()
+}
+
+func (m Model) renderExpandedMessageContent(msg sqs.Message) string {
+	b := &strings.Builder{}
+
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Message ID:"), msg.ID)
+	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("MD5:"), msg.MD5)
+
+	if !msg.SentTimestamp.IsZero() {
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Sent:"), msg.SentTimestamp.Format("2006-01-02 15:04:05"))
+	}
+
+	// Show all attributes
+	if len(msg.Attributes) > 0 {
+		fmt.Fprintln(b)
+		fmt.Fprintf(b, "%s\n", labelStyle.Render("Attributes:"))
+		for k, v := range msg.Attributes {
+			fmt.Fprintf(b, "  %s: %s\n", k, v)
+		}
+	}
+
+	fmt.Fprintln(b)
+	fmt.Fprintf(b, "%s\n", labelStyle.Render("Body:"))
+	// Try to pretty-print JSON
+	body := msg.Body
+	var jsonObj interface{}
+	if err := json.Unmarshal([]byte(body), &jsonObj); err == nil {
+		if pretty, err := json.MarshalIndent(jsonObj, "", "  "); err == nil {
+			body = string(pretty)
+		}
+	}
+	fmt.Fprintln(b, body)
+
+	return b.String()
+}
+
+func (m Model) renderExpandedPopup(background, title string) string {
+	if title == "" {
+		return background
+	}
+
+	header := titleStyle.Render(title)
+	body := m.expandedView.View()
+	footer := dimText.Render("↑↓/j/k scroll • pgup/pgdn page • esc close")
+
+	content := header + "\n" + body + "\n" + footer
+
+	popup := popupBorderStyle.
+		Width(m.expandedWidth()).
+		Height(m.expandedHeight() + 4).
+		Render(content)
+
+	return lipgloss.Place(
+		m.width, m.height-4,
+		lipgloss.Center, lipgloss.Center,
+		popup,
+	)
+}
+
+func truncate(s string, maxLen int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > maxLen {
+		return s[:maxLen] + "..."
+	}
+	return s
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- Adds SQS Queue Browser as Phase 3 of the roadmap
- Browse queues with lazy-load pagination, view message counts and attributes
- Peek messages non-destructively (VisibilityTimeout=0) with JSON auto-formatting
- Expanded popup for queue details and message body
- 14 tests covering pagination, attribute parsing, message peeking, and error handling

## Changes
- `internal/sqs/` — domain client (`ListQueues`, `GetQueueAttributes`, `PeekMessages`), types, tests
- `internal/ui/sqs/` — Bubble Tea UI (model, views, messages, service)
- `cmd/sacha/main.go` — register `sqs` service
- `CLAUDE.md`, `README.md`, `ROADMAP.md` — updated docs

## Test plan
- [x] `go test -race ./...` passes (14 new SQS tests + all existing)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofumpt -l .` — no formatting issues
- [x] Pre-commit hooks pass (format, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)