### PR TITLE
feat(logs): replace table view with plain view, add jq highlight and filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,17 +361,27 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Focused panel has colored border (pink/212); up/down navigation works within focused panel
 - Left panel (groups): search, select, toggle all functionality remains active
   - **Dynamic refresh**: Changing log group selection (via `space` or `a`) while tailing automatically clears events and restarts tailing with new selection
-- Right panel (tail): event navigation, expand, toggle view modes
-- Table columns: TIME (HH:MM:SS), GROUP (log group name), and JSON fields (when detected)
-- Table uses full available width with proportional column sizing
-- Last column expands to fill remaining space
+- Right panel (tail): event navigation, expand, highlight, filter
+- Plain view columns: TIMESTAMP (relative), GROUP (short name), MESSAGE
+- Log group names show only the last path segment (e.g., `/aws/lambda/my-func` → `my-func`)
+- Timestamps: first event shows `HH:MM:SS`, subsequent events show relative offset (`+1.5s`, `+2m30s`, `+1h5m`)
 - `↑/↓` or `j/k` - Navigate within focused panel
 - `enter` or `space` - Expand selected event (popup with formatted JSON) when tail panel focused
-- `v` - Toggle view mode (table/plain)
+- `H` - Open highlight input (jq-style field paths, e.g. `.level .message .statusCode`)
+- `F` - Toggle filter mode: when active, only events containing highlighted JSON fields are shown
 - `x` - Stop tailing (stops watching logs and resets the log panel, same behavior as `q`)
 - `f` - Toggle fullscreen mode (focuses tail panel, hides groups panel)
 - `←/→` or `h/l` - Scroll horizontally (fullscreen mode only, for viewing wide log lines)
 - `q/esc` - Stop tailing
+
+**Highlight & Filter (jq syntax)**
+- Press `H` while the tail panel is focused to open the highlight popup
+- Enter space-separated jq-style field paths: `.level .message .statusCode`
+- Matching JSON field values in log events are rendered with bold yellow highlight
+- Press `F` to toggle filtering: only events whose JSON contains at least one highlighted field are shown
+- Press `F` again to disable filtering and show all events
+- Clearing the highlight input (submitting empty) removes all highlights and disables filtering
+- StatusHelp text (tailing, with highlight active): `↑↓ move, enter expand, H highlight, F filter[on/off], tab/← switch, f fullscreen, x/q stop`
 
 **Expanded Event Popup**
 - Accessed by pressing `enter` or `space` on a selected log event while tailing

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sacha is a two-pane TUI inspired by classic file managers. It keeps you in the t
 
 | Service | What you can do |
 |---------|----------------|
-| **CloudWatch Logs** | Search, multi-select, and tail multiple log groups. JSON logs auto-format as tables. Create, delete, and set retention policies. |
+| **CloudWatch Logs** | Search, multi-select, and tail multiple log groups. Highlight and filter JSON fields with jq syntax. Create, delete, and set retention policies. |
 | **S3** | Browse buckets and objects. Download files and folders recursively. Preview text content. Copy S3 URIs. |
 | **DynamoDB** | Browse tables and scan items. View table metadata, key schema, and GSIs. Inspect full item attributes. |
 | **Lambda** | Browse functions. View configuration, environment variables, layers, and runtime details. |
@@ -148,7 +148,9 @@ Sacha remembers your last-used region and service automatically.
 - **Split-pane TUI** &mdash; left pane lists log groups; right pane shows details or live tail output.
 - **Log group management** &mdash; create (`c`), delete (`d`) with confirmation, set retention policy (`R`) with standard presets (1d to 1y or never).
 - **Multi-group tailing** &mdash; select multiple groups with `space`/`a` and tail them simultaneously with `t`. Dynamic refresh when selection changes.
-- **Smart formatting** &mdash; JSON logs auto-detected and displayed as tables with TIME, GROUP, and extracted fields. Toggle table/plain with `v`.
+- **Compact display** &mdash; log group names show only the last path segment (e.g., `/aws/lambda/my-func` &rarr; `my-func`). Timestamps show the base time for the first event and relative offsets (`+1.5s`, `+2m30s`) for subsequent events.
+- **jq-style highlight** &mdash; press `H` while tailing to enter field paths (e.g., `.level .message .statusCode`). Matching JSON values are highlighted in the log output.
+- **Filter by highlight** &mdash; press `F` to toggle filtering: only events containing the highlighted fields are shown. Press `F` again to show all events.
 - **Panel focus** &mdash; `tab`/`h`/`l` to switch between groups and tail panels. Focused panel highlighted with colored border.
 - **Fullscreen mode** &mdash; press `f` while tailing for a distraction-free view with horizontal scrolling.
 - **Expand events** &mdash; `enter`/`space` to open a scrollable popup with pretty-printed JSON.
@@ -223,7 +225,8 @@ Sacha remembers your last-used region and service automatically.
 | `t` | List | Start tailing selected groups |
 | `tab`, `h/l` | Tailing | Switch panel focus |
 | `enter` / `space` | Tailing | Expand log event |
-| `v` | Tailing | Toggle table / plain view |
+| `H` | Tailing | Set highlight fields (jq syntax: `.level .message`) |
+| `F` | Tailing | Toggle filter by highlighted fields |
 | `f` | Tailing | Toggle fullscreen |
 | `h/l` or `←/→` | Fullscreen | Scroll horizontally |
 | `x` or `q/esc` | Tailing | Stop tailing |

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -114,7 +114,6 @@ type Model struct {
 	pollInterval time.Duration
 	events       []logs.TailEvent
 	view         viewport.Model
-	jsonView     bool // toggle between JSON table view and plain view
 
 	fullscreen    bool           // fullscreen tail mode
 	focus         panel          // which panel has focus
@@ -122,6 +121,12 @@ type Model struct {
 	expandedEvent int            // index of expanded event, -1 if none
 	scrollX       int            // horizontal scroll offset for fullscreen
 	expandedView  viewport.Model // viewport for expanded event
+
+	// Highlight/filter: jq-style field paths like ".level", ".message"
+	highlightFields []string        // fields to highlight in log output
+	highlightInput  textinput.Model // text input for entering highlight expression
+	enteringHL      bool            // whether the highlight input is active
+	filterByHL      bool            // when true, only show events matching highlight fields
 }
 
 func NewModel(client *logs.Client) Model {
@@ -133,15 +138,19 @@ func NewModel(client *logs.Client) Model {
 	ci.Placeholder = "log group name"
 	ci.Prompt = "Name: "
 
+	hi := textinput.New()
+	hi.Placeholder = ".level .message"
+	hi.Prompt = "highlight: "
+
 	return Model{
-		client:        client,
-		selected:      map[string]bool{},
-		loading:       true,
-		search:        ti,
-		createInput:   ci,
-		pollInterval:  defaultPollInterval,
-		jsonView:      true, // default to table view for JSON logs
-		expandedEvent: -1,   // no event expanded
+		client:         client,
+		selected:       map[string]bool{},
+		loading:        true,
+		search:         ti,
+		createInput:    ci,
+		highlightInput: hi,
+		pollInterval:   defaultPollInterval,
+		expandedEvent:  -1, // no event expanded
 	}
 }
 
@@ -291,6 +300,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+		// Handle highlight input
+		if m.enteringHL {
+			switch msg.Type {
+			case tea.KeyEnter:
+				m.enteringHL = false
+				val := strings.TrimSpace(m.highlightInput.Value())
+				if val == "" {
+					m.highlightFields = nil
+				} else {
+					m.highlightFields = strings.Fields(val)
+				}
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
+				m.ensureEventCursorVisible()
+				return m, nil
+			case tea.KeyEscape:
+				m.enteringHL = false
+				return m, nil
+			}
+			var cmd tea.Cmd
+			m.highlightInput, cmd = m.highlightInput.Update(msg)
+			return m, cmd
+		}
+
 		// Handle expanded event popup
 		if m.expandedEvent >= 0 {
 			switch msg.String() {
@@ -316,7 +348,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.focus = panelTail
 				}
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 			}
 		case "left", "h":
 			if m.tailing && m.fullscreen {
@@ -326,7 +358,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if m.scrollX < 0 {
 						m.scrollX = 0
 					}
-					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, true, m.scrollX))
+					m.view.SetContent(m.renderEventsContent(true))
 				}
 			} else if m.tailing && !m.fullscreen {
 				if m.focus == panelTail {
@@ -334,26 +366,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.focus = panelTail
 				}
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 			}
 		case "right", "l":
 			if m.tailing && m.fullscreen {
 				// Horizontal scroll right in fullscreen
 				m.scrollX += 10
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, true, m.scrollX))
+				m.view.SetContent(m.renderEventsContent(true))
 			} else if m.tailing && !m.fullscreen {
 				if m.focus == panelGroups {
 					m.focus = panelTail
 				} else {
 					m.focus = panelGroups
 				}
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 			}
 		case "up", "k":
 			if m.tailing && m.focus == panelTail {
 				if m.eventCursor > 0 {
 					m.eventCursor--
-					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 					m.ensureEventCursorVisible()
 				}
 			} else {
@@ -364,9 +396,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "down", "j":
 			if m.tailing && m.focus == panelTail {
-				if m.eventCursor < len(m.events)-1 {
+				if m.eventCursor < len(m.filteredEvents())-1 {
 					m.eventCursor++
-					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 					m.ensureEventCursorVisible()
 				}
 			} else {
@@ -388,9 +420,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.search.Focus()
 			}
 		case " ":
-			if m.tailing && m.focus == panelTail && len(m.events) > 0 {
+			if m.tailing && m.focus == panelTail && len(m.filteredEvents()) > 0 {
+				evts := m.filteredEvents()
 				m.expandedEvent = m.eventCursor
-				m.expandedView = initExpandedView(m.events[m.eventCursor], m.width, m.height)
+				m.expandedView = initExpandedView(evts[m.eventCursor], m.width, m.height)
 			} else {
 				m.toggleSelection()
 				// Refresh logs when selection changes while tailing
@@ -398,14 +431,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.events = nil
 					m.eventCursor = 0
 					m.tailStart = time.Now().Add(-defaultTailWindow)
-					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 					return m, m.pollTailCmd()
 				}
 			}
 		case "enter":
-			if m.tailing && m.focus == panelTail && len(m.events) > 0 {
+			if m.tailing && m.focus == panelTail && len(m.filteredEvents()) > 0 {
+				evts := m.filteredEvents()
 				m.expandedEvent = m.eventCursor
-				m.expandedView = initExpandedView(m.events[m.eventCursor], m.width, m.height)
+				m.expandedView = initExpandedView(evts[m.eventCursor], m.width, m.height)
 			}
 		case "a":
 			if !m.tailing || m.focus == panelGroups {
@@ -415,7 +449,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.events = nil
 					m.eventCursor = 0
 					m.tailStart = time.Now().Add(-defaultTailWindow)
-					m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+					m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 					return m, m.pollTailCmd()
 				}
 			}
@@ -462,7 +496,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.scrollX = 0 // Reset horizontal scroll when exiting fullscreen
 				}
 				m.setViewportSize(m.bodyHeight())
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 				m.ensureEventCursorVisible()
 			}
 		case "q", "esc":
@@ -471,13 +505,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.fullscreen = false
 				m.focus = panelGroups
 				m.scrollX = 0
+				m.highlightFields = nil
+				m.filterByHL = false
 			}
-		case "v":
-			if m.tailing {
-				m.jsonView = !m.jsonView
-				m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+		case "H":
+			// Open highlight input (jq-style field paths)
+			if m.tailing && m.focus == panelTail {
+				m.enteringHL = true
+				// Pre-fill with current highlight expression
+				m.highlightInput.SetValue(strings.Join(m.highlightFields, " "))
+				return m, m.highlightInput.Focus()
+			}
+		case "F":
+			// Toggle filter-by-highlight mode
+			if m.tailing && m.focus == panelTail && len(m.highlightFields) > 0 {
+				m.filterByHL = !m.filterByHL
+				m.eventCursor = 0
+				m.view.SetContent(m.renderEventsContent(true))
 				m.ensureEventCursorVisible()
-				return m, nil
 			}
 		case "x":
 			// Stop watching and reset Log panel
@@ -488,6 +533,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.events = nil
 				m.eventCursor = 0
 				m.scrollX = 0
+				m.highlightFields = nil
+				m.filterByHL = false
 			}
 		}
 	case pollTailMsg:
@@ -515,12 +562,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			// Auto-scroll to latest events when cursor was at the end
+			evts := m.filteredEvents()
 			if wasAtEnd {
-				m.eventCursor = len(m.events) - 1
-			} else if m.eventCursor >= len(m.events) {
-				m.eventCursor = len(m.events) - 1
+				m.eventCursor = len(evts) - 1
+			} else if m.eventCursor >= len(evts) {
+				m.eventCursor = len(evts) - 1
 			}
-			m.view.SetContent(renderEvents(m.events, m.jsonView, m.eventCursor, m.view.Width, m.focus == panelTail, m.scrollX))
+			if m.eventCursor < 0 {
+				m.eventCursor = 0
+			}
+			m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
 			m.ensureEventCursorVisible()
 		}
 		if m.tailing {
@@ -587,8 +638,14 @@ func (m Model) View() string {
 			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
 	}
 
-	if m.expandedEvent >= 0 && m.expandedEvent < len(m.events) {
-		popup := m.renderExpandedEvent(m.events[m.expandedEvent])
+	if m.enteringHL {
+		popup := m.renderHighlightPopup()
+		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
+			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
+	}
+
+	if evts := m.filteredEvents(); m.expandedEvent >= 0 && m.expandedEvent < len(evts) {
+		popup := m.renderExpandedEvent(evts[m.expandedEvent])
 		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
 			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
 	}
@@ -741,7 +798,7 @@ func (m Model) Tailing() bool {
 
 // Searching reports whether the model has an active text input or overlay.
 func (m Model) Searching() bool {
-	return m.searching || m.creating || m.deleting || m.settingRetention
+	return m.searching || m.creating || m.deleting || m.settingRetention || m.enteringHL
 }
 
 // StatusHelp returns context-aware help text for the status bar.
@@ -761,22 +818,27 @@ func (m Model) StatusHelp() string {
 	if m.searching {
 		return "enter/esc close search"
 	}
+	if m.enteringHL {
+		return "enter apply, esc cancel — use jq syntax: .level .message"
+	}
 	if m.tailing {
-		if m.fullscreen {
-			viewMode := "table"
-			if !m.jsonView {
-				viewMode = "plain"
+		hlInfo := ""
+		if len(m.highlightFields) > 0 {
+			filterState := "off"
+			if m.filterByHL {
+				filterState = "on"
 			}
-			return fmt.Sprintf("↑↓ move, ←→ scroll, enter expand, v [%s], f exit fullscreen, x/q stop", viewMode)
+			hlInfo = fmt.Sprintf(", H highlight, F filter[%s]", filterState)
+		} else {
+			hlInfo = ", H highlight"
+		}
+		if m.fullscreen {
+			return fmt.Sprintf("↑↓ move, ←→ scroll, enter expand%s, f exit fullscreen, x/q stop", hlInfo)
 		}
 		if m.focus == panelGroups {
 			return "↑↓ move, / search, space select, a all, tab/→ switch, f fullscreen, x/q stop"
 		}
-		viewMode := "table"
-		if !m.jsonView {
-			viewMode = "plain"
-		}
-		return fmt.Sprintf("↑↓ move, enter expand, v [%s], tab/← switch, f fullscreen, x/q stop", viewMode)
+		return fmt.Sprintf("↑↓ move, enter expand%s, tab/← switch, f fullscreen, x/q stop", hlInfo)
 	}
 	return "↑↓ move, / search, space select, a all, c create, d delete, R retention, t tail"
 }
@@ -851,27 +913,53 @@ func (m *Model) ensureCursorVisible() {
 }
 
 // eventContentOffset returns the number of header lines rendered before event
-// rows in the viewport content. Table view prepends a blank line and a header
-// row; plain view starts immediately with event rows.
+// rows in the viewport content. Plain view starts immediately with event rows.
 func (m *Model) eventContentOffset() int {
-	if !m.jsonView {
-		return 0
-	}
-	for i, e := range m.events {
-		if i > 10 {
-			break
-		}
-		if parseJSONLog(e.Message) != nil {
-			return 2 // blank line + header row in table view
-		}
-	}
 	return 0
+}
+
+// filteredEvents returns events filtered by highlight fields when filterByHL is active.
+func (m *Model) filteredEvents() []logs.TailEvent {
+	if !m.filterByHL || len(m.highlightFields) == 0 {
+		return m.events
+	}
+	var out []logs.TailEvent
+	for _, e := range m.events {
+		if eventMatchesHighlight(e, m.highlightFields) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// eventMatchesHighlight checks if an event's JSON message contains any of the highlight fields.
+func eventMatchesHighlight(e logs.TailEvent, fields []string) bool {
+	parsed := parseJSONLog(e.Message)
+	if parsed == nil {
+		return false
+	}
+	for _, field := range fields {
+		key := strings.TrimPrefix(field, ".")
+		if key == "" {
+			continue
+		}
+		if _, ok := parsed[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// renderEventsContent builds the viewport content for the tail panel.
+func (m *Model) renderEventsContent(showCursor bool) string {
+	return renderEvents(m.filteredEvents(), m.eventCursor, m.view.Width, showCursor, m.scrollX, m.highlightFields)
 }
 
 // ensureEventCursorVisible adjusts the viewport's YOffset so the line
 // corresponding to eventCursor is within the visible area.
 func (m *Model) ensureEventCursorVisible() {
-	if len(m.events) == 0 || m.view.Height <= 0 {
+	evts := m.filteredEvents()
+	if len(evts) == 0 || m.view.Height <= 0 {
 		return
 	}
 	cursorLine := m.eventCursor + m.eventContentOffset()

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -3,7 +3,6 @@ package logs
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -42,11 +41,6 @@ var (
 	dimText = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("241"))
 
-	// tableHeaderStyle for table column headers
-	tableHeaderStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("39")).
-				Bold(true)
-
 	statusStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("44"))
 
@@ -61,6 +55,10 @@ var (
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("63")).
 			Padding(1, 2)
+
+	highlightStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("226")).
+			Bold(true)
 )
 
 func (m Model) renderGroups() string {
@@ -129,7 +127,16 @@ func (m Model) renderTail() string {
 	if !m.tailing {
 		return m.renderGroupDetails()
 	}
-	return fmt.Sprintf("%s\n%s", titleStyle.Render("Logs"), m.view.View())
+	header := titleStyle.Render("Logs")
+	if len(m.highlightFields) > 0 {
+		hlText := strings.Join(m.highlightFields, " ")
+		if m.filterByHL {
+			header += "  " + statusStyle.Render(fmt.Sprintf("[HL: %s] [filter: on]", hlText))
+		} else {
+			header += "  " + statusStyle.Render(fmt.Sprintf("[HL: %s]", hlText))
+		}
+	}
+	return fmt.Sprintf("%s\n%s", header, m.view.View())
 }
 
 func (m Model) renderGroupDetails() string {
@@ -165,52 +172,89 @@ func (m Model) renderGroupDetails() string {
 	return b.String()
 }
 
-func renderEvents(events []logs.TailEvent, jsonView bool, cursor, width int, showCursor bool, scrollX int) string {
+func renderEvents(events []logs.TailEvent, cursor, width int, showCursor bool, scrollX int, highlightFields []string) string {
 	if len(events) == 0 {
 		return ""
 	}
+	return renderEventsPlain(events, cursor, width, showCursor, scrollX, highlightFields)
+}
 
-	// If JSON view is disabled, always use plain rendering
-	if !jsonView {
-		return renderEventsPlain(events, cursor, width, showCursor, scrollX)
+// shortGroupName returns the last path segment of a log group name.
+// e.g. "/aws/lambda/my-func" -> "my-func"
+func shortGroupName(name string) string {
+	if i := strings.LastIndex(name, "/"); i >= 0 && i < len(name)-1 {
+		return name[i+1:]
 	}
+	return name
+}
 
-	// Check if events contain JSON - sample first few
-	hasJSON := false
-	var allKeys []string
-	keySet := make(map[string]bool)
+// relativeTimestamp formats a timestamp relative to a base time.
+// The first event shows the full HH:MM:SS, subsequent events show +Xs offset.
+func relativeTimestamp(ts, base time.Time) string {
+	if ts.Equal(base) {
+		return ts.Format("15:04:05")
+	}
+	diff := ts.Sub(base)
+	secs := diff.Seconds()
+	if secs < 0 {
+		return ts.Format("15:04:05")
+	}
+	if secs < 60 {
+		return fmt.Sprintf("+%.1fs", secs)
+	}
+	if secs < 3600 {
+		return fmt.Sprintf("+%.0fm%.0fs", secs/60, float64(int(secs)%60))
+	}
+	return fmt.Sprintf("+%.0fh%.0fm", secs/3600, float64(int(secs)%3600)/60)
+}
 
-	for i, e := range events {
-		if i > 10 {
-			break // Sample first 10 to detect pattern
+// highlightMessage applies highlighting to a message for the given jq-style field paths.
+// Fields are specified as ".fieldName" and matching values are highlighted in the output.
+func highlightMessage(msg string, fields []string) string {
+	if len(fields) == 0 {
+		return msg
+	}
+	parsed := parseJSONLog(msg)
+	if parsed == nil {
+		return msg
+	}
+	for _, field := range fields {
+		key := strings.TrimPrefix(field, ".")
+		if key == "" {
+			continue
 		}
-		if parsed := parseJSONLog(e.Message); parsed != nil {
-			hasJSON = true
-			for k := range parsed {
-				if !keySet[k] {
-					keySet[k] = true
-					allKeys = append(allKeys, k)
-				}
+		val, ok := parsed[key]
+		if !ok {
+			continue
+		}
+		valStr := formatValue(val)
+		if valStr == "" {
+			continue
+		}
+		// Highlight occurrences of the value in the message
+		msg = strings.ReplaceAll(msg, valStr, highlightStyle.Render(valStr))
+	}
+	return msg
+}
+
+func renderEventsPlain(events []logs.TailEvent, cursor, width int, showCursor bool, scrollX int, highlightFields []string) string {
+	var b strings.Builder
+
+	// Find the min (earliest) timestamp as the base for relative display
+	var baseTime time.Time
+	if len(events) > 0 {
+		baseTime = events[0].Timestamp
+		for _, e := range events[1:] {
+			if e.Timestamp.Before(baseTime) {
+				baseTime = e.Timestamp
 			}
 		}
 	}
 
-	if !hasJSON {
-		// Fall back to original rendering
-		return renderEventsPlain(events, cursor, width, showCursor, scrollX)
-	}
-
-	// Render as table
-	return renderEventsTable(events, allKeys, cursor, width, showCursor, scrollX)
-}
-
-func renderEventsPlain(events []logs.TailEvent, cursor, width int, showCursor bool, scrollX int) string {
-	var b strings.Builder
-
 	// Calculate column widths
-	timeWidth := 25 // RFC3339 format
+	timeWidth := 12 // enough for "+XXmXXs" or "HH:MM:SS"
 	groupWidth := 20
-	separators := 6 // " | " twice
+	separators := 6 // " │ " twice
 	pointer := 1    // "▶" or " "
 	msgWidth := width - timeWidth - groupWidth - separators - pointer
 	if msgWidth < 20 {
@@ -218,9 +262,11 @@ func renderEventsPlain(events []logs.TailEvent, cursor, width int, showCursor bo
 	}
 
 	for i, e := range events {
-		ts := padRight(e.Timestamp.Format(time.RFC3339), timeWidth)
-		group := padRight(truncate(e.LogGroup, groupWidth), groupWidth)
-		msg := truncate(strings.TrimSpace(e.Message), msgWidth+scrollX)
+		ts := padRight(relativeTimestamp(e.Timestamp, baseTime), timeWidth)
+		group := padRight(truncate(shortGroupName(e.LogGroup), groupWidth), groupWidth)
+		msg := strings.TrimSpace(e.Message)
+		msg = highlightMessage(msg, highlightFields)
+		msg = truncate(msg, msgWidth+scrollX)
 		line := fmt.Sprintf("%s │ %s │ %s", ts, group, msg)
 		line = scrollLine(line, scrollX)
 		if showCursor && i == cursor {
@@ -229,139 +275,6 @@ func renderEventsPlain(events []logs.TailEvent, cursor, width int, showCursor bo
 			fmt.Fprintln(&b, " "+line)
 		}
 	}
-	return b.String()
-}
-
-func renderEventsTable(events []logs.TailEvent, keys []string, cursor, width int, showCursor bool, scrollX int) string {
-	// Sort keys for consistent column order (timestamp-like fields first)
-	sort.Slice(keys, func(i, j int) bool {
-		priority := map[string]int{
-			"timestamp": 0, "time": 1, "level": 2,
-			"message": 3, "msg": 4,
-		}
-		pi, oki := priority[strings.ToLower(keys[i])]
-		pj, okj := priority[strings.ToLower(keys[j])]
-		if oki && okj {
-			return pi < pj
-		}
-		if oki {
-			return true
-		}
-		if okj {
-			return false
-		}
-		return keys[i] < keys[j]
-	})
-
-	// Build columns: TIME + GROUP + JSON keys
-	columns := append([]string{"TIME", "GROUP"}, keys...)
-	numCols := len(columns)
-
-	// Pre-compute all cell values and track column widths
-	type row struct {
-		cells []string
-	}
-	rows := make([]row, len(events))
-	colWidths := make([]int, numCols)
-
-	// Initialize widths from headers
-	for i, col := range columns {
-		colWidths[i] = len(col)
-	}
-
-	// Compute cell values and update widths
-	for i, e := range events {
-		cells := make([]string, numCols)
-		cells[0] = e.Timestamp.Format("15:04:05")
-		cells[1] = e.LogGroup
-
-		parsed := parseJSONLog(e.Message)
-		if parsed == nil {
-			// Non-JSON row - show raw message in third column
-			if numCols > 2 {
-				cells[2] = strings.TrimSpace(e.Message)
-			}
-		} else {
-			for j, k := range keys {
-				if v, ok := parsed[k]; ok {
-					cells[j+2] = formatValue(v)
-				}
-			}
-		}
-
-		rows[i] = row{cells: cells}
-
-		// Update column widths
-		for j, cell := range cells {
-			if len(cell) > colWidths[j] {
-				colWidths[j] = len(cell)
-			}
-		}
-	}
-
-	// Calculate available width (subtract pointer, separators, padding)
-	pointer := 2                                       // "▶ " or "  "
-	separators := (numCols - 1) * 3                    // " │ " between columns
-	availableWidth := width - pointer - separators - 2 // 2 for safety margin
-
-	// Distribute width: fixed columns first, then expand flexible ones
-	totalCurrentWidth := 0
-	for _, w := range colWidths {
-		totalCurrentWidth += w
-	}
-
-	if totalCurrentWidth < availableWidth {
-		// Expand last column (usually message) to fill space
-		extra := availableWidth - totalCurrentWidth
-		colWidths[numCols-1] += extra
-	} else {
-		// Cap columns proportionally
-		const maxColWidth = 40
-		for i := range colWidths {
-			if colWidths[i] > maxColWidth && i < numCols-1 {
-				colWidths[i] = maxColWidth
-			}
-		}
-		// Recalculate and give remaining to last column
-		usedWidth := 0
-		for i := 0; i < numCols-1; i++ {
-			usedWidth += colWidths[i]
-		}
-		lastColWidth := availableWidth - usedWidth
-		if lastColWidth < 10 {
-			lastColWidth = 10
-		}
-		colWidths[numCols-1] = lastColWidth
-	}
-
-	// Render table
-	var b strings.Builder
-
-	// Top padding
-	fmt.Fprintln(&b)
-
-	// Header row
-	headerParts := make([]string, 0, len(columns))
-	for i, col := range columns {
-		headerParts = append(headerParts, padRight(col, colWidths[i]))
-	}
-	headerLine := scrollLine(strings.Join(headerParts, "   "), scrollX)
-	fmt.Fprintln(&b, " "+tableHeaderStyle.Render(headerLine))
-
-	// Data rows
-	for i, r := range rows {
-		rowParts := make([]string, 0, len(r.cells))
-		for j, cell := range r.cells {
-			rowParts = append(rowParts, padRight(truncate(cell, colWidths[j]), colWidths[j]))
-		}
-		line := scrollLine(strings.Join(rowParts, "   "), scrollX)
-		if showCursor && i == cursor {
-			fmt.Fprintln(&b, hoverPointer+hoverStyle.Render(line))
-		} else {
-			fmt.Fprintln(&b, " "+line)
-		}
-	}
-
 	return b.String()
 }
 
@@ -454,6 +367,22 @@ func checkbox(selected bool) string {
 		return "x"
 	}
 	return " "
+}
+
+func (m Model) renderHighlightPopup() string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, titleStyle.Render("Highlight Fields"))
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("Enter jq-style field paths separated by spaces:"))
+	fmt.Fprintln(b, dimText.Render("  .level .message .statusCode"))
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, m.highlightInput.View())
+	fmt.Fprintln(b)
+	if len(m.highlightFields) > 0 {
+		fmt.Fprintf(b, "%s %s\n", dimText.Render("Active:"), strings.Join(m.highlightFields, " "))
+	}
+	fmt.Fprintln(b, dimText.Render("Enter to apply, Esc to cancel, empty to clear"))
+	return popupStyle.Render(b.String())
 }
 
 func (m Model) renderCreatePopup() string {


### PR DESCRIPTION
Remove the table/JSON view toggle in CloudWatch Logs tailing. The plain
view is now the only view mode, with these improvements:

- Log group names show only the last path segment (e.g. /aws/lambda/name → name)
- Timestamps show base HH:MM:SS for the earliest event, then relative
  offsets (+1.5s, +2m30s) for subsequent events
- Press H to enter jq-style field paths (.level .message) to highlight
  matching JSON values in bold yellow
- Press F to filter: only events containing highlighted fields are shown

https://claude.ai/code/session_01Xg33UrfyTqgQrep11qyvaJ