### PR TITLE
Add cross-account monitoring support for CloudWatch Logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,17 @@ go 1.24.2
 
 require (
 	github.com/atotto/clipboard v0.1.4
-	github.com/aws/aws-sdk-go-v2 v1.41.1
+	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.289.1
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0
+	github.com/aws/aws-sdk-go-v2/service/oam v1.23.13
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -24,8 +26,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
@@ -36,8 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
+	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
-github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
+github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -10,10 +10,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.7 h1:tHK47VqqtJxOymRrNtUXN5SP/zUT
 github.com/aws/aws-sdk-go-v2/credentials v1.19.7/go.mod h1:qOZk8sPDrxhf+4Wf4oT2urYJrYt3RejHSzgAquYeppw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 h1:xOLELNKGp2vsiteLsvLPwxC+mYmO6OZ8PYgiuPJzF8U=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17/go.mod h1:5M5CI3D12dNOtH3/mk6minaRwI2/37ifCURZISxA/IQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 h1:WWLqlh79iO48yLkj1v3ISRNiv+3KdQoZ6JWyfcsyQik=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17/go.mod h1:EhG22vHRrvF8oXSTYStZhJc1aUgKtnJe+aOiFEV90cM=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 h1:/sECfyq2JTifMI2JPyZ4bdRN77zJmr6SrS1eL3augIA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19/go.mod h1:dMf8A5oAqr9/oxOfLkC/c2LU/uMcALP0Rgn2BD5LWn0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 h1:AWeJMk33GTBf6J20XJe6qZoRSJo0WfUhsMdUKhoODXE=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19/go.mod h1:+GWrYoaAsV7/4pNHpwh1kiNLXkKaSoppxQq9lbH8Ejw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R50aTBHkA7vu0lK+k=
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0 h1:u66DMbJWDFXs9458RAHNtq2d0gyqcZFV4mzRwfjM358=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0/go.mod h1:ogjbkxFgFOjG3dYFQ8irC92gQfpfMDcy1RDKNSZWXNU=
+github.com/aws/aws-sdk-go-v2/service/oam v1.23.13 h1:hIwoaKlyEi8VmhV1ZSVgrpmEusXvtAlLo8PFxjFtI0g=
+github.com/aws/aws-sdk-go-v2/service/oam v1.23.13/go.mod h1:qwOk7HZhZy6Ir04sZsu4M0ELu9g/pIjte7oufE8MzlU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 h1:VrhDvQib/i0lxvr3zqlUwLwJP4fpmpyD9wYG1vfSu+Y=
@@ -50,8 +52,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 h1:gd84Omyu9JLriJVCbGApcLz
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13/go.mod h1:sTGThjphYE4Ohw8vJiRStAcu3rbjtXRsdNB0TvZ5wwo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/pJ1jOWYlFDJTjRQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/aws/monitoring.go
+++ b/internal/aws/monitoring.go
@@ -1,0 +1,76 @@
+package awsx
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+)
+
+// OAMAPI captures the AWS OAM methods we use.
+type OAMAPI interface {
+	ListSinks(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error)
+	ListAttachedLinks(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error)
+}
+
+// MonitoringInfo holds cross-account observability metadata.
+type MonitoringInfo struct {
+	IsMonitoring   bool
+	SinkARN        string
+	LinkedAccounts []LinkedAccount
+}
+
+// LinkedAccount represents a source account linked to the monitoring account.
+type LinkedAccount struct {
+	AccountID string
+	Label     string
+}
+
+// DetectMonitoringAccount checks if the current account is a CloudWatch
+// monitoring account by looking for OAM sinks. If a sink exists, it fetches
+// the linked source accounts.
+func DetectMonitoringAccount(ctx context.Context, cfg aws.Config) MonitoringInfo {
+	client := oam.NewFromConfig(cfg)
+	return detectMonitoringWithAPI(ctx, client)
+}
+
+func detectMonitoringWithAPI(ctx context.Context, api OAMAPI) MonitoringInfo {
+	sinksOut, err := api.ListSinks(ctx, &oam.ListSinksInput{})
+	if err != nil || len(sinksOut.Items) == 0 {
+		return MonitoringInfo{}
+	}
+
+	sinkARN := ""
+	if sinksOut.Items[0].Arn != nil {
+		sinkARN = *sinksOut.Items[0].Arn
+	}
+
+	info := MonitoringInfo{
+		IsMonitoring: true,
+		SinkARN:      sinkARN,
+	}
+
+	if sinkARN == "" {
+		return info
+	}
+
+	linksOut, err := api.ListAttachedLinks(ctx, &oam.ListAttachedLinksInput{
+		SinkIdentifier: &sinkARN,
+	})
+	if err != nil {
+		return info
+	}
+
+	for _, link := range linksOut.Items {
+		acct := LinkedAccount{}
+		if link.Label != nil {
+			acct.Label = *link.Label
+			acct.AccountID = *link.Label
+		}
+		if acct.AccountID != "" {
+			info.LinkedAccounts = append(info.LinkedAccounts, acct)
+		}
+	}
+
+	return info
+}

--- a/internal/aws/monitoring_test.go
+++ b/internal/aws/monitoring_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type mockOAMAPI struct {
-	listSinksFn        func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error)
+	listSinksFn         func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error)
 	listAttachedLinksFn func(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error)
 }
 

--- a/internal/aws/monitoring_test.go
+++ b/internal/aws/monitoring_test.go
@@ -1,0 +1,112 @@
+package awsx
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+	oamtypes "github.com/aws/aws-sdk-go-v2/service/oam/types"
+)
+
+type mockOAMAPI struct {
+	listSinksFn        func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error)
+	listAttachedLinksFn func(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error)
+}
+
+func (m *mockOAMAPI) ListSinks(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error) {
+	if m.listSinksFn != nil {
+		return m.listSinksFn(ctx, params, optFns...)
+	}
+	return &oam.ListSinksOutput{}, nil
+}
+
+func (m *mockOAMAPI) ListAttachedLinks(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error) {
+	if m.listAttachedLinksFn != nil {
+		return m.listAttachedLinksFn(ctx, params, optFns...)
+	}
+	return &oam.ListAttachedLinksOutput{}, nil
+}
+
+func TestDetectMonitoringAccount(t *testing.T) {
+	tests := []struct {
+		name         string
+		mock         *mockOAMAPI
+		wantMonitor  bool
+		wantAccounts int
+	}{
+		{
+			name: "not a monitoring account (no sinks)",
+			mock: &mockOAMAPI{
+				listSinksFn: func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error) {
+					return &oam.ListSinksOutput{Items: []oamtypes.ListSinksItem{}}, nil
+				},
+			},
+			wantMonitor:  false,
+			wantAccounts: 0,
+		},
+		{
+			name: "not a monitoring account (API error)",
+			mock: &mockOAMAPI{
+				listSinksFn: func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error) {
+					return nil, errors.New("access denied")
+				},
+			},
+			wantMonitor:  false,
+			wantAccounts: 0,
+		},
+		{
+			name: "monitoring account with linked accounts",
+			mock: &mockOAMAPI{
+				listSinksFn: func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error) {
+					return &oam.ListSinksOutput{
+						Items: []oamtypes.ListSinksItem{
+							{Arn: aws.String("arn:aws:oam:us-east-1:111111111111:sink/abc123")},
+						},
+					}, nil
+				},
+				listAttachedLinksFn: func(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error) {
+					return &oam.ListAttachedLinksOutput{
+						Items: []oamtypes.ListAttachedLinksItem{
+							{Label: aws.String("222222222222")},
+							{Label: aws.String("333333333333")},
+						},
+					}, nil
+				},
+			},
+			wantMonitor:  true,
+			wantAccounts: 2,
+		},
+		{
+			name: "monitoring account with link fetch error",
+			mock: &mockOAMAPI{
+				listSinksFn: func(ctx context.Context, params *oam.ListSinksInput, optFns ...func(*oam.Options)) (*oam.ListSinksOutput, error) {
+					return &oam.ListSinksOutput{
+						Items: []oamtypes.ListSinksItem{
+							{Arn: aws.String("arn:aws:oam:us-east-1:111111111111:sink/abc123")},
+						},
+					}, nil
+				},
+				listAttachedLinksFn: func(ctx context.Context, params *oam.ListAttachedLinksInput, optFns ...func(*oam.Options)) (*oam.ListAttachedLinksOutput, error) {
+					return nil, errors.New("access denied")
+				},
+			},
+			wantMonitor:  true,
+			wantAccounts: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := detectMonitoringWithAPI(context.Background(), tt.mock)
+
+			if info.IsMonitoring != tt.wantMonitor {
+				t.Errorf("IsMonitoring = %v, want %v", info.IsMonitoring, tt.wantMonitor)
+			}
+			if len(info.LinkedAccounts) != tt.wantAccounts {
+				t.Errorf("LinkedAccounts count = %d, want %d", len(info.LinkedAccounts), tt.wantAccounts)
+			}
+		})
+	}
+}

--- a/internal/aws/service.go
+++ b/internal/aws/service.go
@@ -17,9 +17,10 @@ type Service interface {
 
 // ServiceOptions contains dependencies shared with services.
 type ServiceOptions struct {
-	Logger    ServiceLogger
-	Cache     *cache.Cache
-	AccountID string
+	Logger     ServiceLogger
+	Cache      *cache.Cache
+	AccountID  string
+	Monitoring MonitoringInfo
 }
 
 // ServiceLogger is a narrow logging interface used by services.

--- a/internal/logs/client.go
+++ b/internal/logs/client.go
@@ -31,6 +31,8 @@ func NewClient(cfg aws.Config) *Client {
 
 type LogGroup struct {
 	Name          string
+	ARN           string
+	AccountID     string
 	RetentionDays int32
 	StoredBytes   int64
 	CreationTime  time.Time
@@ -43,12 +45,27 @@ type TailEvent struct {
 	Message   string
 }
 
+// ListLogGroupsOptions configures cross-account log group listing.
+type ListLogGroupsOptions struct {
+	IncludeLinkedAccounts bool
+	AccountIdentifiers    []string
+}
+
 // ListLogGroups returns a page of log groups and the next token, if any.
-func (c *Client) ListLogGroups(ctx context.Context, nextToken *string) ([]LogGroup, *string, error) {
-	out, err := c.api.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+func (c *Client) ListLogGroups(ctx context.Context, nextToken *string, opts ...ListLogGroupsOptions) ([]LogGroup, *string, error) {
+	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		NextToken: nextToken,
 		Limit:     aws.Int32(50),
-	})
+	}
+
+	if len(opts) > 0 && opts[0].IncludeLinkedAccounts {
+		input.IncludeLinkedAccounts = aws.Bool(true)
+		if len(opts[0].AccountIdentifiers) > 0 {
+			input.AccountIdentifiers = opts[0].AccountIdentifiers
+		}
+	}
+
+	out, err := c.api.DescribeLogGroups(ctx, input)
 	if err != nil {
 		return nil, nil, fmt.Errorf("describe log groups: %w", err)
 	}
@@ -59,8 +76,11 @@ func (c *Client) ListLogGroups(ctx context.Context, nextToken *string) ([]LogGro
 		if g.CreationTime != nil {
 			created = time.Unix(0, *g.CreationTime*int64(time.Millisecond))
 		}
+		arn := aws.ToString(g.LogGroupArn)
 		groups = append(groups, LogGroup{
 			Name:          aws.ToString(g.LogGroupName),
+			ARN:           arn,
+			AccountID:     extractAccountFromARN(arn),
 			RetentionDays: aws.ToInt32(g.RetentionInDays),
 			StoredBytes:   aws.ToInt64(g.StoredBytes),
 			CreationTime:  created,
@@ -68,6 +88,33 @@ func (c *Client) ListLogGroups(ctx context.Context, nextToken *string) ([]LogGro
 	}
 
 	return groups, out.NextToken, nil
+}
+
+// extractAccountFromARN extracts the account ID from an ARN.
+// ARN format: arn:aws:logs:region:account-id:log-group:name
+func extractAccountFromARN(arn string) string {
+	parts := splitARN(arn)
+	if len(parts) >= 5 {
+		return parts[4]
+	}
+	return ""
+}
+
+func splitARN(arn string) []string {
+	if arn == "" {
+		return nil
+	}
+	// Split on ":"
+	var parts []string
+	start := 0
+	for i := 0; i < len(arn); i++ {
+		if arn[i] == ':' {
+			parts = append(parts, arn[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, arn[start:])
+	return parts
 }
 
 // CreateLogGroup creates a new log group with the given name.

--- a/internal/logs/client_test.go
+++ b/internal/logs/client_test.go
@@ -575,3 +575,66 @@ func TestListLogGroupsCreationTime(t *testing.T) {
 		t.Errorf("CreationTime = %v, want %v", groups[0].CreationTime, expected)
 	}
 }
+
+func TestListLogGroupsWithLinkedAccounts(t *testing.T) {
+	client := &Client{
+		api: &mockCloudWatchLogsAPI{
+			describeLogGroupsFn: func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+				if params.IncludeLinkedAccounts == nil || !*params.IncludeLinkedAccounts {
+					t.Error("expected IncludeLinkedAccounts to be true")
+				}
+				if len(params.AccountIdentifiers) != 1 || params.AccountIdentifiers[0] != "222222222222" {
+					t.Errorf("expected AccountIdentifiers [222222222222], got %v", params.AccountIdentifiers)
+				}
+				return &cloudwatchlogs.DescribeLogGroupsOutput{
+					LogGroups: []types.LogGroup{
+						{
+							LogGroupName: aws.String("/aws/lambda/cross-account-func"),
+							LogGroupArn:  aws.String("arn:aws:logs:us-east-1:222222222222:log-group:/aws/lambda/cross-account-func"),
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	opts := ListLogGroupsOptions{
+		IncludeLinkedAccounts: true,
+		AccountIdentifiers:   []string{"222222222222"},
+	}
+	groups, _, err := client.ListLogGroups(context.Background(), nil, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+
+	if groups[0].AccountID != "222222222222" {
+		t.Errorf("AccountID = %q, want %q", groups[0].AccountID, "222222222222")
+	}
+
+	if groups[0].ARN != "arn:aws:logs:us-east-1:222222222222:log-group:/aws/lambda/cross-account-func" {
+		t.Errorf("unexpected ARN: %s", groups[0].ARN)
+	}
+}
+
+func TestExtractAccountFromARN(t *testing.T) {
+	tests := []struct {
+		arn  string
+		want string
+	}{
+		{"arn:aws:logs:us-east-1:123456789012:log-group:/test", "123456789012"},
+		{"arn:aws:logs:eu-west-1:999999999999:log-group:/my/group:*", "999999999999"},
+		{"", ""},
+		{"not-an-arn", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractAccountFromARN(tt.arn)
+		if got != tt.want {
+			t.Errorf("extractAccountFromARN(%q) = %q, want %q", tt.arn, got, tt.want)
+		}
+	}
+}

--- a/internal/logs/client_test.go
+++ b/internal/logs/client_test.go
@@ -600,7 +600,7 @@ func TestListLogGroupsWithLinkedAccounts(t *testing.T) {
 
 	opts := ListLogGroupsOptions{
 		IncludeLinkedAccounts: true,
-		AccountIdentifiers:   []string{"222222222222"},
+		AccountIdentifiers:    []string{"222222222222"},
 	}
 	groups, _, err := client.ListLogGroups(context.Background(), nil, opts)
 	if err != nil {

--- a/internal/ui/app/model.go
+++ b/internal/ui/app/model.go
@@ -46,11 +46,11 @@ func NewModel(loader awsx.Loader, services map[string]awsx.Service, runtime conf
 	accountID := awsx.ResolveAccountID(context.Background(), cfg, runtime.Profile)
 	monitoring := awsx.DetectMonitoringAccount(context.Background(), cfg)
 	m := Model{
-		loader:    loader,
-		services:  services,
-		runtime:   runtime,
-		cfg:       cfg,
-		logger:    logger,
+		loader:     loader,
+		services:   services,
+		runtime:    runtime,
+		cfg:        cfg,
+		logger:     logger,
 		cache:      cache.New(),
 		accountID:  accountID,
 		monitoring: monitoring,

--- a/internal/ui/app/model.go
+++ b/internal/ui/app/model.go
@@ -26,8 +26,9 @@ type Model struct {
 
 	logger *zerolog.Logger
 
-	cache     *cache.Cache
-	accountID string
+	cache      *cache.Cache
+	accountID  string
+	monitoring awsx.MonitoringInfo
 
 	regionSelector  optionSelector
 	serviceSelector optionSelector
@@ -43,14 +44,16 @@ func NewModel(loader awsx.Loader, services map[string]awsx.Service, runtime conf
 		runtime.Region = cfg.Region
 	}
 	accountID := awsx.ResolveAccountID(context.Background(), cfg, runtime.Profile)
+	monitoring := awsx.DetectMonitoringAccount(context.Background(), cfg)
 	m := Model{
 		loader:    loader,
 		services:  services,
 		runtime:   runtime,
 		cfg:       cfg,
 		logger:    logger,
-		cache:     cache.New(),
-		accountID: accountID,
+		cache:      cache.New(),
+		accountID:  accountID,
+		monitoring: monitoring,
 	}
 	m.regionSelector = newOptionSelectorWithViews(awsRegions, commonRegions)
 	m.serviceSelector = newOptionSelector(serviceNames(services))
@@ -120,6 +123,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() string {
 	header := fmt.Sprintf("profile: %s | region: %s | service: %s", emptyIf(m.runtime.Profile, "default"), emptyIf(m.runtime.Region, "sdk-default"), m.runtime.Service)
+	if m.monitoring.IsMonitoring {
+		acctLabel := "all accounts"
+		if sa, ok := m.service.(accountAware); ok {
+			if sel := sa.SelectedAccount(); sel != "" {
+				acctLabel = sel
+			}
+		}
+		header += fmt.Sprintf(" | monitoring (%s)", acctLabel)
+	}
 	if m.regionSelector.active {
 		return m.overlayView(header, m.regionSelector.View(minWidth(m.width, 60)))
 	}
@@ -151,9 +163,10 @@ func (m *Model) activateService(name string) error {
 		return fmt.Errorf("unknown service %q; available services: %s", name, strings.Join(valid, ", "))
 	}
 	model, err := svc.Init(context.Background(), m.cfg, awsx.ServiceOptions{
-		Logger:    newLoggerAdapter(m.logger),
-		Cache:     m.cache,
-		AccountID: m.accountID,
+		Logger:     newLoggerAdapter(m.logger),
+		Cache:      m.cache,
+		AccountID:  m.accountID,
+		Monitoring: m.monitoring,
 	})
 	if err != nil {
 		return err
@@ -264,6 +277,10 @@ func isSearching(m tea.Model) bool {
 		return s.Searching()
 	}
 	return false
+}
+
+type accountAware interface {
+	SelectedAccount() string
 }
 
 type statusProvider interface {

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	awsx "github.com/sachamama/sacha/internal/aws"
 	"github.com/sachamama/sacha/internal/cache"
 	"github.com/sachamama/sacha/internal/logs"
 )
@@ -134,9 +135,16 @@ type Model struct {
 	highlightInput  textinput.Model // text input for entering highlight expression
 	enteringHL      bool            // whether the highlight input is active
 	filterByHL      bool            // when true, only show events matching highlight fields
+
+	// Cross-account monitoring
+	monitoring       awsx.MonitoringInfo
+	accountOptions   []string // "All Accounts" + linked account IDs
+	selectedAccount  string   // "" means all accounts, otherwise an account ID
+	selectingAccount bool     // whether the account selector is active
+	accountCursor    int
 }
 
-func NewModel(client *logs.Client, c *cache.Cache, cacheKey cache.Key) Model {
+func NewModel(client *logs.Client, c *cache.Cache, cacheKey cache.Key, monitoring ...awsx.MonitoringInfo) Model {
 	ti := textinput.New()
 	ti.Placeholder = "filter log groups"
 	ti.Prompt = "/ "
@@ -149,6 +157,19 @@ func NewModel(client *logs.Client, c *cache.Cache, cacheKey cache.Key) Model {
 	hi.Placeholder = ".level .message"
 	hi.Prompt = "highlight: "
 
+	var mon awsx.MonitoringInfo
+	if len(monitoring) > 0 {
+		mon = monitoring[0]
+	}
+
+	var accountOpts []string
+	if mon.IsMonitoring {
+		accountOpts = append(accountOpts, "All Accounts")
+		for _, la := range mon.LinkedAccounts {
+			accountOpts = append(accountOpts, la.AccountID)
+		}
+	}
+
 	m := Model{
 		client:         client,
 		selected:       map[string]bool{},
@@ -160,6 +181,8 @@ func NewModel(client *logs.Client, c *cache.Cache, cacheKey cache.Key) Model {
 		highlightInput: hi,
 		pollInterval:   defaultPollInterval,
 		expandedEvent:  -1, // no event expanded
+		monitoring:     mon,
+		accountOptions: accountOpts,
 	}
 	if c != nil {
 		if items, ok := c.Get(cacheKey); ok {
@@ -309,6 +332,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "esc", "q":
 				m.settingRetention = false
 				m.statusLine = ""
+			}
+			return m, nil
+		}
+
+		if m.selectingAccount {
+			switch msg.String() {
+			case "up", "k":
+				if m.accountCursor > 0 {
+					m.accountCursor--
+				}
+			case "down", "j":
+				if m.accountCursor < len(m.accountOptions)-1 {
+					m.accountCursor++
+				}
+			case "enter":
+				m.selectingAccount = false
+				if m.accountCursor == 0 {
+					m.selectedAccount = "" // "All Accounts"
+				} else {
+					m.selectedAccount = m.accountOptions[m.accountCursor]
+				}
+				// Reload log groups with the new account filter
+				if m.cache != nil {
+					m.cache.Delete(m.cacheKey)
+				}
+				m.logGroups = nil
+				m.nextGroupToken = nil
+				m.cursor = 0
+				m.listOffset = 0
+				m.loading = true
+				m.statusLine = "Loading log groups..."
+				return m, m.loadLogGroupsCmd()
+			case "esc", "q":
+				m.selectingAccount = false
 			}
 			return m, nil
 		}
@@ -510,6 +567,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.retentionCursor = 0
 				}
 			}
+		case "m":
+			// Open account selector (only in monitoring mode, not while tailing)
+			if m.monitoring.IsMonitoring && !m.tailing && len(m.accountOptions) > 0 {
+				m.selectingAccount = true
+				m.accountCursor = 0
+				// Pre-select current account
+				for i, opt := range m.accountOptions {
+					if (m.selectedAccount == "" && i == 0) || opt == m.selectedAccount {
+						m.accountCursor = i
+						break
+					}
+				}
+			}
 		case "t":
 			if !m.tailing && len(m.selectedGroups()) > 0 {
 				m.tailing = true
@@ -700,6 +770,12 @@ func (m Model) View() string {
 			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
 	}
 
+	if m.selectingAccount {
+		popup := m.renderAccountPicker()
+		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
+			lipgloss.WithWhitespaceBackground(lipgloss.Color("0")))
+	}
+
 	if evts := m.filteredEvents(); m.expandedEvent >= 0 && m.expandedEvent < len(evts) {
 		popup := m.renderExpandedEvent(evts[m.expandedEvent])
 		view = lipgloss.Place(m.width, m.height-4, lipgloss.Center, lipgloss.Center, popup,
@@ -709,10 +785,22 @@ func (m Model) View() string {
 	return view
 }
 
+func (m Model) listOpts() []logs.ListLogGroupsOptions {
+	if !m.monitoring.IsMonitoring {
+		return nil
+	}
+	opts := logs.ListLogGroupsOptions{IncludeLinkedAccounts: true}
+	if m.selectedAccount != "" {
+		opts.AccountIdentifiers = []string{m.selectedAccount}
+	}
+	return []logs.ListLogGroupsOptions{opts}
+}
+
 func (m Model) loadLogGroupsCmd() tea.Cmd {
+	opts := m.listOpts()
 	return func() tea.Msg {
 		ctx := context.Background()
-		groups, nextToken, err := m.client.ListLogGroups(ctx, nil)
+		groups, nextToken, err := m.client.ListLogGroups(ctx, nil, opts...)
 		if err != nil {
 			return logGroupsLoadedMsg{err: err}
 		}
@@ -722,9 +810,10 @@ func (m Model) loadLogGroupsCmd() tea.Cmd {
 
 func (m Model) loadMoreLogGroupsCmd() tea.Cmd {
 	token := m.nextGroupToken
+	opts := m.listOpts()
 	return func() tea.Msg {
 		ctx := context.Background()
-		groups, nextToken, err := m.client.ListLogGroups(ctx, token)
+		groups, nextToken, err := m.client.ListLogGroups(ctx, token, opts...)
 		return moreLogGroupsLoadedMsg{groups: groups, nextToken: nextToken, err: err}
 	}
 }
@@ -873,7 +962,13 @@ func (m Model) Tailing() bool {
 
 // Searching reports whether the model has an active text input or overlay.
 func (m Model) Searching() bool {
-	return m.searching || m.creating || m.deleting || m.settingRetention || m.enteringHL
+	return m.searching || m.creating || m.deleting || m.settingRetention || m.enteringHL || m.selectingAccount
+}
+
+// SelectedAccount returns the selected account ID for cross-account filtering.
+// Returns empty string when showing all accounts.
+func (m Model) SelectedAccount() string {
+	return m.selectedAccount
 }
 
 // StatusHelp returns context-aware help text for the status bar.
@@ -896,6 +991,9 @@ func (m Model) StatusHelp() string {
 	if m.enteringHL {
 		return "enter apply, esc cancel — use jq syntax: .level .message"
 	}
+	if m.selectingAccount {
+		return "↑↓ move, enter select, esc cancel"
+	}
 	if m.tailing {
 		hlInfo := ""
 		if len(m.highlightFields) > 0 {
@@ -915,7 +1013,11 @@ func (m Model) StatusHelp() string {
 		}
 		return fmt.Sprintf("↑↓ move, enter expand, y copy%s, tab/← switch, f fullscreen, x/q stop", hlInfo)
 	}
-	return "↑↓ move, / search, space select, a all, c create, d delete, R retention, t tail, y copy, ctrl+r refresh"
+	help := "↑↓ move, / search, space select, a all, c create, d delete, R retention, t tail, y copy, ctrl+r refresh"
+	if m.monitoring.IsMonitoring {
+		help += ", m account"
+	}
+	return help
 }
 
 func (m *Model) setViewportSize(bodyHeight int) {

--- a/internal/ui/logs/service.go
+++ b/internal/ui/logs/service.go
@@ -32,6 +32,6 @@ func (CloudWatchLogsService) Init(ctx context.Context, cfg sdkaws.Config, opts a
 		Region:    cfg.Region,
 		Service:   "cloudwatch-logs",
 	}
-	model := NewModel(client, opts.Cache, cacheKey)
+	model := NewModel(client, opts.Cache, cacheKey, opts.Monitoring)
 	return model, nil
 }

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -175,6 +175,10 @@ func (m Model) renderGroupDetails() string {
 	fmt.Fprintln(b)
 	fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Name:"), g.Name)
 
+	if g.AccountID != "" {
+		fmt.Fprintf(b, "%s  %s\n", labelStyle.Render("Account:"), g.AccountID)
+	}
+
 	if g.RetentionDays > 0 {
 		fmt.Fprintf(b, "%s  %d days\n", labelStyle.Render("Retention:"), g.RetentionDays)
 	} else {
@@ -491,6 +495,32 @@ func (m Model) renderRetentionPicker() string {
 			fmt.Fprintf(b, "  %s %s\n", hoverPointer, cursorStyle.Render(opt.label))
 		} else {
 			fmt.Fprintf(b, "    %s\n", opt.label)
+		}
+	}
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, dimText.Render("↑↓ move, enter select, esc cancel"))
+	return popupStyle.Render(b.String())
+}
+
+func (m Model) renderAccountPicker() string {
+	b := &strings.Builder{}
+	fmt.Fprintln(b, titleStyle.Render("Select Account"))
+	fmt.Fprintln(b, dimText.Render("Filter log groups by source account"))
+	fmt.Fprintln(b)
+	for i, opt := range m.accountOptions {
+		label := opt
+		if i == 0 {
+			// "All Accounts" option
+			label = opt
+		}
+		// Show current selection
+		if (m.selectedAccount == "" && i == 0) || opt == m.selectedAccount {
+			label += " ●"
+		}
+		if i == m.accountCursor {
+			fmt.Fprintf(b, "  %s %s\n", hoverPointer, cursorStyle.Render(label))
+		} else {
+			fmt.Fprintf(b, "    %s\n", label)
 		}
 	}
 	fmt.Fprintln(b)


### PR DESCRIPTION
## Summary

Add support for CloudWatch cross-account observability in the logs viewer. This enables users in a monitoring account to view and manage log groups from linked source accounts through the OAM (Observability Access Manager) service.

## Changes

- **New monitoring detection**: Added `internal/aws/monitoring.go` with `DetectMonitoringAccount()` to identify if the current account is a CloudWatch monitoring account and fetch linked source accounts via OAM API
- **Cross-account log group listing**: Extended `ListLogGroups()` in `internal/logs/client.go` to support filtering by account ID and extracting account information from log group ARNs
- **Account selector UI**: Added interactive account picker in logs model (`internal/ui/logs/model.go`) accessible via 'm' key, allowing users to filter log groups by source account
- **Account display**: Show account ID in log group details view when available
- **Service integration**: Pass `MonitoringInfo` through service initialization pipeline to make monitoring metadata available to UI components
- **Header indicator**: Display monitoring status and selected account in the main app header

## Test Plan

- Added comprehensive unit tests for `DetectMonitoringAccount()` covering success cases, API errors, and linked account retrieval
- Added unit tests for cross-account log group listing and ARN account extraction
- Existing tests continue to pass with new optional parameters

https://claude.ai/code/session_01KprQjuwPcY7CCHWgnU8KWG