### PR TITLE
feat(ui): add copy shortcut and scroll improvements to log event popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,8 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Accessed by pressing `enter` or `space` on a selected log event while tailing
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `g`/`G` - Jump to top/bottom
+- `y` - Copy event message to clipboard
 - `esc` - Close popup
 
 ### S3 (`internal/ui/s3/`)

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -187,6 +187,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.setViewportSize(m.bodyHeight())
 		m.ensureCursorVisible()
+		if m.expandedEvent >= 0 {
+			evts := m.filteredEvents()
+			if m.expandedEvent < len(evts) {
+				yOffset := m.expandedView.YOffset
+				m.expandedView = initExpandedView(evts[m.expandedEvent], m.width, m.height)
+				m.expandedView.SetYOffset(yOffset)
+			}
+		}
 	case logGroupsLoadedMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -365,6 +373,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.expandedView.HalfPageUp()
 			case "pgdn":
 				m.expandedView.HalfPageDown()
+			case "g":
+				m.expandedView.GotoTop()
+			case "G":
+				m.expandedView.GotoBottom()
+			case "y":
+				evts := m.filteredEvents()
+				if m.expandedEvent < len(evts) {
+					msg := evts[m.expandedEvent].Message
+					_ = clipboard.WriteAll(msg)
+					m.statusLine = fmt.Sprintf("Copied event (%d chars)", len(msg))
+				}
 			}
 			return m, nil
 		}
@@ -879,7 +898,7 @@ func (m Model) Searching() bool {
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
 	if m.expandedEvent >= 0 {
-		return "↑↓ scroll, pgup/pgdn page, esc close"
+		return "↑↓ scroll, pgup/pgdn page, g/G top/bottom, y copy, esc close"
 	}
 	if m.deleting {
 		return "y confirm delete, n/esc cancel"

--- a/internal/ui/logs/views.go
+++ b/internal/ui/logs/views.go
@@ -426,7 +426,7 @@ func (m Model) renderExpandedEvent(e logs.TailEvent) string {
 	fmt.Fprintln(b, dimText.Render("Message:"))
 	fmt.Fprintln(b, m.expandedView.View())
 	fmt.Fprintln(b)
-	fmt.Fprintln(b, dimText.Render("↑↓/j/k scroll, pgup/pgdn page, esc close"))
+	fmt.Fprintln(b, dimText.Render("↑↓/j/k scroll, pgup/pgdn page, g/G top/bottom, y copy, esc close"))
 
 	// Size popup based on content
 	maxWidth := m.width - 10


### PR DESCRIPTION
Adds a y key in the expanded log event popup to copy the message to
clipboard, and adds g/G to jump to top/bottom of the scrollable content.
Also reinitializes the popup viewport on window resize so vertical
scroll continues to work after terminal size changes.