### PR TITLE
fix(logs): preserve tail scroll position across new events

### DIFF
--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -695,29 +695,60 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if len(msg.events) > 0 {
 			m.tailStart = msg.nextStart
-			m.events = append(m.events, msg.events...)
-			if len(m.events) > 1000 {
-				trimmed := len(m.events) - 1000
-				m.events = m.events[trimmed:]
-				if !m.autoScroll {
-					m.eventCursor -= trimmed
-					if m.eventCursor < 0 {
-						m.eventCursor = 0
-					}
+
+			// When following, stay pinned to the latest event. Otherwise the
+			// user has scrolled up to inspect older logs, so preserve their
+			// position: anchor on the event currently under the cursor and the
+			// screen row it occupies. New events are appended at the bottom and
+			// the buffer is trimmed from the front once it grows past the cap —
+			// both shift indices, so anchoring on the event itself (rather than
+			// a raw index) keeps the view stable across either change.
+			follow := m.autoScroll
+			var anchor logs.TailEvent
+			var haveAnchor bool
+			var anchorRow int
+			if !follow {
+				evts := m.filteredEvents()
+				if m.eventCursor >= 0 && m.eventCursor < len(evts) {
+					anchor = evts[m.eventCursor]
+					haveAnchor = true
+					anchorRow = m.eventCursor + m.eventContentOffset() - m.view.YOffset
 				}
 			}
-			// Auto-scroll to latest events when autoScroll is enabled
+
+			m.events = append(m.events, msg.events...)
+			if len(m.events) > 1000 {
+				m.events = m.events[len(m.events)-1000:]
+			}
+
 			evts := m.filteredEvents()
-			if m.autoScroll {
+			if follow {
 				m.eventCursor = len(evts) - 1
-			} else if m.eventCursor >= len(evts) {
-				m.eventCursor = len(evts) - 1
+				if m.eventCursor < 0 {
+					m.eventCursor = 0
+				}
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
+				m.ensureEventCursorVisible()
+			} else {
+				if haveAnchor {
+					if idx := indexOfEvent(evts, anchor); idx >= 0 {
+						m.eventCursor = idx
+					} else {
+						// The anchored event was trimmed off the top.
+						m.eventCursor = 0
+						anchorRow = 0
+					}
+				}
+				if m.eventCursor > len(evts)-1 {
+					m.eventCursor = len(evts) - 1
+				}
+				if m.eventCursor < 0 {
+					m.eventCursor = 0
+				}
+				m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
+				m.view.SetYOffset(m.eventCursor + m.eventContentOffset() - anchorRow)
+				m.ensureEventCursorVisible()
 			}
-			if m.eventCursor < 0 {
-				m.eventCursor = 0
-			}
-			m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
-			m.ensureEventCursorVisible()
 		}
 		if m.tailing {
 			return m, tea.Tick(m.pollInterval, func(time.Time) tea.Msg { return pollTailMsg{} })
@@ -961,10 +992,25 @@ func (m Model) selectedCount() int {
 	return count
 }
 
+// indexOfEvent returns the index of target within events, or -1 if absent.
+// Used to re-locate the cursor's anchor event after the tail buffer is
+// appended to or trimmed.
+func indexOfEvent(events []logs.TailEvent, target logs.TailEvent) int {
+	for i := range events {
+		if events[i] == target {
+			return i
+		}
+	}
+	return -1
+}
+
 func (m Model) getCopyText() string {
 	// When tailing and focused on tail panel, copy the selected event message
-	if m.tailing && m.focus == panelTail && len(m.events) > 0 && m.eventCursor < len(m.events) {
-		return m.events[m.eventCursor].Message
+	if m.tailing && m.focus == panelTail {
+		evts := m.filteredEvents()
+		if m.eventCursor >= 0 && m.eventCursor < len(evts) {
+			return evts[m.eventCursor].Message
+		}
 	}
 	// Otherwise copy the log group name under cursor
 	groups := m.filteredGroups()

--- a/internal/ui/logs/model_test.go
+++ b/internal/ui/logs/model_test.go
@@ -1,0 +1,135 @@
+package logs
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sachamama/sacha/internal/logs"
+)
+
+// newTailModel builds a Model in the tailing state with a sized viewport,
+// suitable for exercising tail scroll handling without a live AWS client.
+func newTailModel(t *testing.T) Model {
+	t.Helper()
+	m := Model{
+		selected:      map[string]bool{"/test/group": true},
+		expandedEvent: -1,
+		pollInterval:  defaultPollInterval,
+		width:         120,
+		height:        30,
+		tailing:       true,
+		focus:         panelTail,
+	}
+	m.setViewportSize(m.bodyHeight())
+	if m.view.Height <= 0 {
+		t.Fatalf("expected positive viewport height, got %d", m.view.Height)
+	}
+	return m
+}
+
+// makeEvents returns n events with distinct, identifiable messages.
+func makeEvents(start, n int) []logs.TailEvent {
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	out := make([]logs.TailEvent, 0, n)
+	for i := 0; i < n; i++ {
+		idx := start + i
+		out = append(out, logs.TailEvent{
+			Timestamp: base.Add(time.Duration(idx) * time.Second),
+			LogGroup:  "/test/group",
+			LogStream: "stream",
+			Message:   fmt.Sprintf("event-%d", idx),
+		})
+	}
+	return out
+}
+
+func (m Model) update(t *testing.T, msg interface{}) Model {
+	t.Helper()
+	next, _ := m.Update(msg)
+	mm, ok := next.(Model)
+	if !ok {
+		t.Fatalf("Update returned unexpected model type %T", next)
+	}
+	return mm
+}
+
+// TestTailFollowPinsToBottom verifies that while following, new events keep
+// the cursor and viewport pinned to the latest event.
+func TestTailFollowPinsToBottom(t *testing.T) {
+	m := newTailModel(t)
+	m.autoScroll = true
+
+	m = m.update(t, tailUpdateMsg{events: makeEvents(0, 100), nextStart: time.Now()})
+	if m.eventCursor != 99 {
+		t.Fatalf("expected cursor at last event 99, got %d", m.eventCursor)
+	}
+
+	m = m.update(t, tailUpdateMsg{events: makeEvents(100, 10), nextStart: time.Now()})
+	if got := len(m.events); got != 110 {
+		t.Fatalf("expected 110 events, got %d", got)
+	}
+	if m.eventCursor != 109 {
+		t.Fatalf("expected cursor to follow to 109, got %d", m.eventCursor)
+	}
+	// The latest event should sit on the last visible row of the viewport.
+	if row := m.eventCursor - m.view.YOffset; row != m.view.Height-1 {
+		t.Fatalf("expected latest event on bottom row %d, got row %d", m.view.Height-1, row)
+	}
+}
+
+// TestTailPreservesScrollOnAppend verifies that when the user has scrolled up
+// (not following), appending new events does not move their view.
+func TestTailPreservesScrollOnAppend(t *testing.T) {
+	m := newTailModel(t)
+	m.autoScroll = true
+	m = m.update(t, tailUpdateMsg{events: makeEvents(0, 100), nextStart: time.Now()})
+
+	// Scroll up to event 50.
+	m.autoScroll = false
+	m.eventCursor = 50
+	m.view.SetYOffset(40) // cursor sits on screen row 10
+	anchorMsg := m.filteredEvents()[m.eventCursor].Message
+	anchorOffset := m.view.YOffset
+
+	m = m.update(t, tailUpdateMsg{events: makeEvents(100, 10), nextStart: time.Now()})
+
+	if got := m.filteredEvents()[m.eventCursor].Message; got != anchorMsg {
+		t.Fatalf("cursor moved off anchor event: want %q got %q", anchorMsg, got)
+	}
+	if m.view.YOffset != anchorOffset {
+		t.Fatalf("scroll position changed on append: want offset %d got %d", anchorOffset, m.view.YOffset)
+	}
+}
+
+// TestTailPreservesScrollOnTrim verifies that when the buffer overflows and is
+// trimmed from the front, the user's scroll position is preserved by anchoring
+// on the event under the cursor rather than a raw index.
+func TestTailPreservesScrollOnTrim(t *testing.T) {
+	m := newTailModel(t)
+	m.autoScroll = true
+	m = m.update(t, tailUpdateMsg{events: makeEvents(0, 1000), nextStart: time.Now()})
+
+	// Scroll up to a known event well away from the bottom.
+	m.autoScroll = false
+	m.eventCursor = 500
+	m.view.SetYOffset(495) // cursor on screen row 5
+	anchorMsg := m.filteredEvents()[m.eventCursor].Message
+	anchorRow := m.eventCursor - m.view.YOffset
+
+	// Push 50 more events, forcing a 50-event trim from the front.
+	m = m.update(t, tailUpdateMsg{events: makeEvents(1000, 50), nextStart: time.Now()})
+
+	if got := len(m.events); got != 1000 {
+		t.Fatalf("expected buffer capped at 1000, got %d", got)
+	}
+	if got := m.filteredEvents()[m.eventCursor].Message; got != anchorMsg {
+		t.Fatalf("cursor lost anchor after trim: want %q got %q", anchorMsg, got)
+	}
+	if m.eventCursor != 450 {
+		t.Fatalf("expected cursor shifted to 450 after trim, got %d", m.eventCursor)
+	}
+	if gotRow := m.eventCursor - m.view.YOffset; gotRow != anchorRow {
+		t.Fatalf("screen row changed after trim: want %d got %d", anchorRow, gotRow)
+	}
+}


### PR DESCRIPTION
When tailing, the viewport scroll position could jump as new events
arrived. While the user is scrolled up to inspect older logs (not
following), appended events and the front-trim that caps the buffer at
1000 events both shift event indices. The old code adjusted eventCursor
by the raw trim count but never shifted the viewport YOffset, so once the
buffer filled the view reset on each poll.

Anchor on the event under the cursor and its on-screen row, then restore
both after the buffer mutates, so the user's position stays put across
appends and trims. Following mode still pins to the latest event. Also
fixes getCopyText to index the filtered event slice consistently.

Adds tests covering follow, append-preserve, and trim-preserve cases.