### PR TITLE
feat(ui): add page-up/down and home/end navigation across views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,15 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - `ctrl+r` - Refresh current view (reload from AWS)
 - `ctrl+c` - Quit
 
+### Global List & Scroll Navigation
+
+These keys work in every list view and scrollable popup/preview:
+- `pgup`/`pgdn` (`PageUp`/`PageDown`) - Move a full page up/down (cursor pages in lists; viewport pages in popups)
+- `home` - Jump to the first item / top of the popup
+- `end` - Jump to the last item / bottom of the popup
+
+In list views, page-down and `end` trigger lazy-loading of the next page when the cursor lands near the end, mirroring `↓`/`j`. Implemented per model via a `jumpCursor` helper (and `jumpGroupCursor`/`jumpEventCursor` in logs).
+
 ### CloudWatch Logs (`internal/ui/logs/`)
 
 **Log Groups View (default)**
@@ -389,7 +398,7 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Accessed by pressing `enter` or `space` on a selected log event while tailing
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
-- `g`/`G` - Jump to top/bottom
+- `g`/`G` or `home`/`end` - Jump to top/bottom
 - `y` - Copy event message to clipboard
 - `esc` - Close popup
 
@@ -415,6 +424,8 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 
 **Preview Mode**
 - `↑/↓` - Scroll
+- `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `p/esc` - Close preview
 
 ### DynamoDB (`internal/ui/dynamodb/`)
@@ -438,6 +449,7 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Accessed by pressing `enter` or `space` on a selected item
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `esc` - Close popup
 
 ### Lambda (`internal/ui/lambda/`)
@@ -453,6 +465,7 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Accessed by pressing `enter` or `space` on a selected function
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `esc` - Close popup
 
 ### SSM Parameter Store (`internal/ui/ssm/`)
@@ -468,6 +481,7 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 - Accessed by pressing `enter` or `space` on a leaf parameter
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `esc` - Close popup
 
 ### SQS (`internal/ui/sqs/`)
@@ -488,6 +502,7 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 **Expanded Popup (queue or message)**
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `esc` - Close popup
 
 ### EC2 (`internal/ui/ec2/`)
@@ -502,4 +517,5 @@ When users navigate into a sub-view (e.g., opening a DynamoDB table, entering an
 **Expanded Instance Popup**
 - `↑/↓` or `j/k` - Scroll up/down
 - `pgup/pgdn` - Page up/down
+- `home`/`end` - Jump to top/bottom
 - `esc` - Close popup

--- a/internal/ui/dynamodb/model.go
+++ b/internal/ui/dynamodb/model.go
@@ -206,8 +206,12 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.expandedView.ScrollDown(1)
 		case "pgup":
 			m.expandedView.HalfPageUp()
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.HalfPageDown()
+		case "home":
+			m.expandedView.GotoTop()
+		case "end":
+			m.expandedView.GotoBottom()
 		}
 		return m, nil
 	}
@@ -290,9 +294,13 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusLine = "Copied: " + arn
 		}
 	case "pgup":
-		m.detailViewport.HalfPageUp()
-	case "pgdn":
-		m.detailViewport.HalfPageDown()
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(m.maxCursorIndex())
 	case "ctrl+r":
 		if m.table == "" {
 			if m.cache != nil {
@@ -416,6 +424,40 @@ func (m *Model) clampCursor() {
 		m.cursor = 0
 	}
 	m.ensureCursorVisible()
+}
+
+// jumpCursor moves the cursor to idx (clamped to the list bounds), updates the
+// detail pane and scroll visibility, and returns the command to refresh
+// details, lazy-loading the next page when the cursor lands near the end.
+// Works in both the table list and item list. Used by page and home/end
+// navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := m.maxCursorIndex()
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	if m.table == "" {
+		m.description = nil
+	}
+	m.updateDetailViewport()
+	cmd := m.onCursorMove()
+	if m.table == "" && m.tableToken != nil && !m.loadingMore && m.cursor >= len(m.filteredTables())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreTablesCmd())
+	}
+	if m.table != "" && m.lastEvaluatedKey != nil && !m.loadingMore && m.cursor >= len(m.filteredItems())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreItemsCmd())
+	}
+	return cmd
 }
 
 func (m Model) currentTableName() string {
@@ -638,13 +680,13 @@ func (m Model) Searching() bool {
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
 	if m.expandedItem >= 0 {
-		return "↑↓ scroll, pgup/pgdn page, esc close"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close"
 	}
 	if m.searching {
 		return "enter/esc close search"
 	}
 	if m.table == "" {
-		return "↑↓ move, / search, enter open, pgup/pgdn details, y copy ARN, ctrl+r refresh"
+		return "↑↓ move, pgup/pgdn page, / search, enter open, y copy ARN, ctrl+r refresh"
 	}
-	return "↑↓ move, / search, enter expand, pgup/pgdn details, y copy ARN, ctrl+r refresh, esc/h back"
+	return "↑↓ move, pgup/pgdn page, / search, enter expand, y copy ARN, ctrl+r refresh, esc/h back"
 }

--- a/internal/ui/dynamodb/model_test.go
+++ b/internal/ui/dynamodb/model_test.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -123,6 +124,50 @@ func TestCursorNavigation(t *testing.T) {
 	m = sendKey(m, "k")
 	if m.cursor != 0 {
 		t.Errorf("expected cursor at 0, got %d", m.cursor)
+	}
+}
+
+func TestPageAndJumpNavigation(t *testing.T) {
+	tables := make([]dynamodb.Table, 100)
+	for i := range tables {
+		tables[i] = dynamodb.Table{Name: fmt.Sprintf("t%03d", i)}
+	}
+	m := newTestModel(tables)
+
+	// End jumps to the last item.
+	m = sendSpecialKey(m, tea.KeyEnd)
+	if m.cursor != 99 {
+		t.Fatalf("end: expected cursor 99, got %d", m.cursor)
+	}
+
+	// Home jumps back to the first item.
+	m = sendSpecialKey(m, tea.KeyHome)
+	if m.cursor != 0 {
+		t.Fatalf("home: expected cursor 0, got %d", m.cursor)
+	}
+
+	// PageDown advances by a full page.
+	page := m.listHeight()
+	m = sendSpecialKey(m, tea.KeyPgDown)
+	if m.cursor != page {
+		t.Fatalf("pgdown: expected cursor %d, got %d", page, m.cursor)
+	}
+
+	// PageUp returns to the top (single page back from page-sized offset).
+	m = sendSpecialKey(m, tea.KeyPgUp)
+	if m.cursor != 0 {
+		t.Fatalf("pgup: expected cursor 0, got %d", m.cursor)
+	}
+}
+
+func TestPageNavigationClampsAndNoopsWhenEmpty(t *testing.T) {
+	// Empty list: page/jump keys must not move the cursor or panic.
+	m := newTestModel(nil)
+	for _, k := range []tea.KeyType{tea.KeyEnd, tea.KeyHome, tea.KeyPgDown, tea.KeyPgUp} {
+		m = sendSpecialKey(m, k)
+		if m.cursor != 0 {
+			t.Fatalf("expected cursor to stay 0 on empty list, got %d", m.cursor)
+		}
 	}
 }
 
@@ -486,14 +531,14 @@ func TestStatusHelp(t *testing.T) {
 
 	// Table list view
 	help := m.StatusHelp()
-	if help != "↑↓ move, / search, enter open, pgup/pgdn details, y copy ARN, ctrl+r refresh" {
+	if help != "↑↓ move, pgup/pgdn page, / search, enter open, y copy ARN, ctrl+r refresh" {
 		t.Errorf("unexpected help: %q", help)
 	}
 
 	// Items view
 	m.table = "test"
 	help = m.StatusHelp()
-	if help != "↑↓ move, / search, enter expand, pgup/pgdn details, y copy ARN, ctrl+r refresh, esc/h back" {
+	if help != "↑↓ move, pgup/pgdn page, / search, enter expand, y copy ARN, ctrl+r refresh, esc/h back" {
 		t.Errorf("unexpected help: %q", help)
 	}
 
@@ -508,7 +553,7 @@ func TestStatusHelp(t *testing.T) {
 	m.searching = false
 	m.expandedItem = 0
 	help = m.StatusHelp()
-	if help != "↑↓ scroll, pgup/pgdn page, esc close" {
+	if help != "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close" {
 		t.Errorf("unexpected help: %q", help)
 	}
 }

--- a/internal/ui/dynamodb/views.go
+++ b/internal/ui/dynamodb/views.go
@@ -191,10 +191,9 @@ func (m Model) renderRight() string {
 
 	fmt.Fprint(b, m.detailViewport.View())
 
-	// Show scroll hint when content overflows
+	// Show truncation hint when content overflows the detail pane.
 	if m.detailViewport.TotalLineCount() > m.detailViewport.VisibleLineCount() {
-		pct := int(m.detailViewport.ScrollPercent() * 100)
-		fmt.Fprintf(b, "\n%s", dimText.Render(fmt.Sprintf("  ↕ %d%% (pgup/pgdn)", pct)))
+		fmt.Fprintf(b, "\n%s", dimText.Render("  ↓ more details below"))
 	}
 
 	return b.String()
@@ -335,7 +334,7 @@ func (m Model) renderExpandedItem() string {
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, m.expandedView.View())
 	fmt.Fprintln(b)
-	fmt.Fprintln(b, dimText.Render("↑↓/j/k scroll, pgup/pgdn page, esc close"))
+	fmt.Fprintln(b, dimText.Render("↑↓/j/k scroll, pgup/pgdn page, home/end top/bottom, esc close"))
 
 	maxWidth := m.width - 10
 	if maxWidth > 100 {

--- a/internal/ui/ec2/model.go
+++ b/internal/ui/ec2/model.go
@@ -138,8 +138,12 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.expandedView.ScrollDown(1)
 		case "pgup":
 			m.expandedView.HalfPageUp()
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.HalfPageDown()
+		case "home":
+			m.expandedView.GotoTop()
+		case "end":
+			m.expandedView.GotoBottom()
 		}
 		return m, nil
 	}
@@ -177,6 +181,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	case "pgup":
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(len(m.filteredInstances()) - 1)
 	case "enter", " ":
 		// Expand instance details in popup
 		instances := m.filteredInstances()
@@ -294,6 +306,29 @@ func (m *Model) clampCursor() {
 	m.ensureCursorVisible()
 }
 
+// jumpCursor moves the cursor to idx (clamped to the list bounds), updates
+// scroll visibility, and lazy-loads the next page when the cursor lands near
+// the end. Used by page and home/end navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := len(m.filteredInstances()) - 1
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	if m.nextToken != nil && !m.loadingMore && m.cursor >= len(m.filteredInstances())-5 {
+		m.loadingMore = true
+		return m.loadMoreInstancesCmd()
+	}
+	return nil
+}
+
 func (m Model) filteredInstances() []ec2.Instance {
 	if m.search.Value() == "" {
 		return m.instances
@@ -372,7 +407,7 @@ func (m Model) Searching() bool {
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
 	if m.expandedInst >= 0 {
-		return "↑↓ scroll, pgup/pgdn page, esc close"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close"
 	}
 	if m.searching {
 		return "enter/esc close search"

--- a/internal/ui/lambda/model.go
+++ b/internal/ui/lambda/model.go
@@ -150,8 +150,12 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.expandedView.ScrollDown(1)
 		case "pgup":
 			m.expandedView.HalfPageUp()
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.HalfPageDown()
+		case "home":
+			m.expandedView.GotoTop()
+		case "end":
+			m.expandedView.GotoBottom()
 		}
 		return m, nil
 	}
@@ -192,6 +196,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
+	case "pgup":
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(len(m.filteredFunctions()) - 1)
 	case "enter", " ":
 		// Expand function details in popup
 		functions := m.filteredFunctions()
@@ -315,6 +327,31 @@ func (m *Model) clampCursor() {
 	m.ensureCursorVisible()
 }
 
+// jumpCursor moves the cursor to idx (clamped to the list bounds), updates
+// scroll visibility, and returns the command to refresh details, lazy-loading
+// the next page when the cursor lands near the end. Used by page and home/end
+// navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := len(m.filteredFunctions()) - 1
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	cmd := m.onCursorMove()
+	if m.nextToken != nil && !m.loadingMore && m.cursor >= len(m.filteredFunctions())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreFunctionsCmd())
+	}
+	return cmd
+}
+
 func (m Model) currentFunctionName() string {
 	functions := m.filteredFunctions()
 	if len(functions) == 0 || m.cursor >= len(functions) {
@@ -404,7 +441,7 @@ func (m Model) Searching() bool {
 // StatusHelp returns context-aware help text for the status bar.
 func (m Model) StatusHelp() string {
 	if m.expandedFunc >= 0 {
-		return "↑↓ scroll, pgup/pgdn page, esc close"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close"
 	}
 	if m.searching {
 		return "enter/esc close search"

--- a/internal/ui/logs/model.go
+++ b/internal/ui/logs/model.go
@@ -428,11 +428,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.expandedView.ScrollDown(1)
 			case "pgup":
 				m.expandedView.HalfPageUp()
-			case "pgdn":
+			case "pgdown", "pgdn":
 				m.expandedView.HalfPageDown()
-			case "g":
+			case "g", "home":
 				m.expandedView.GotoTop()
-			case "G":
+			case "G", "end":
 				m.expandedView.GotoBottom()
 			case "y":
 				evts := m.filteredEvents()
@@ -522,6 +522,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, m.loadMoreLogGroupsCmd()
 					}
 				}
+			}
+		case "pgup":
+			if m.tailing && m.focus == panelTail {
+				m.jumpEventCursor(m.eventCursor - m.eventPageSize())
+			} else {
+				return m, m.jumpGroupCursor(m.cursor - m.listHeight())
+			}
+		case "pgdown", "pgdn":
+			if m.tailing && m.focus == panelTail {
+				m.jumpEventCursor(m.eventCursor + m.eventPageSize())
+			} else {
+				return m, m.jumpGroupCursor(m.cursor + m.listHeight())
+			}
+		case "home":
+			if m.tailing && m.focus == panelTail {
+				m.jumpEventCursor(0)
+			} else {
+				return m, m.jumpGroupCursor(0)
+			}
+		case "end":
+			if m.tailing && m.focus == panelTail {
+				m.jumpEventCursor(len(m.filteredEvents()) - 1)
+			} else {
+				return m, m.jumpGroupCursor(len(m.filteredGroups()) - 1)
 			}
 		case "/":
 			if !m.tailing || m.focus == panelGroups {
@@ -1152,6 +1176,61 @@ func (m *Model) ensureCursorVisible() {
 	if m.listOffset < 0 {
 		m.listOffset = 0
 	}
+}
+
+// jumpGroupCursor moves the log-group cursor to idx (clamped to the list
+// bounds), updates scroll visibility, and lazy-loads the next page when the
+// cursor lands near the end. Used by page and home/end navigation.
+func (m *Model) jumpGroupCursor(idx int) tea.Cmd {
+	last := len(m.filteredGroups()) - 1
+	if idx > last {
+		idx = last
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if last < 0 || idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	if !m.tailing && m.nextGroupToken != nil && !m.loadingMore && m.cursor >= len(m.filteredGroups())-5 {
+		m.loadingMore = true
+		return m.loadMoreLogGroupsCmd()
+	}
+	return nil
+}
+
+// eventPageSize returns the number of event rows that fit in the tail viewport,
+// used as the page increment for page-up/down navigation.
+func (m *Model) eventPageSize() int {
+	if m.view.Height > 1 {
+		return m.view.Height
+	}
+	return 1
+}
+
+// jumpEventCursor moves the tail-event cursor to idx (clamped to the event
+// list), re-renders, and keeps the viewport pinned to the cursor. Following
+// (auto-scroll) re-engages only when the cursor reaches the latest event. Used
+// by page and home/end navigation while the tail panel is focused.
+func (m *Model) jumpEventCursor(idx int) {
+	evts := m.filteredEvents()
+	last := len(evts) - 1
+	if last < 0 {
+		m.eventCursor = 0
+		return
+	}
+	if idx > last {
+		idx = last
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	m.eventCursor = idx
+	m.autoScroll = m.eventCursor >= last
+	m.view.SetContent(m.renderEventsContent(m.focus == panelTail))
+	m.ensureEventCursorVisible()
 }
 
 // eventContentOffset returns the number of header lines rendered before event

--- a/internal/ui/logs/model_test.go
+++ b/internal/ui/logs/model_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachamama/sacha/internal/logs"
 )
 
@@ -75,6 +76,85 @@ func TestTailFollowPinsToBottom(t *testing.T) {
 	// The latest event should sit on the last visible row of the viewport.
 	if row := m.eventCursor - m.view.YOffset; row != m.view.Height-1 {
 		t.Fatalf("expected latest event on bottom row %d, got row %d", m.view.Height-1, row)
+	}
+}
+
+// TestTailEventPageAndJumpKeys verifies page-up/down and home/end navigation
+// over tail events, including how following (auto-scroll) re-engages only at
+// the latest event.
+func TestTailEventPageAndJumpKeys(t *testing.T) {
+	m := newTailModel(t)
+	m.autoScroll = true
+	m = m.update(t, tailUpdateMsg{events: makeEvents(0, 100), nextStart: time.Now()})
+	if m.eventCursor != 99 {
+		t.Fatalf("expected cursor pinned to last event 99, got %d", m.eventCursor)
+	}
+
+	// Home jumps to the first event and stops following.
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyHome})
+	if m.eventCursor != 0 {
+		t.Fatalf("home: expected cursor 0, got %d", m.eventCursor)
+	}
+	if m.autoScroll {
+		t.Fatal("home: expected auto-scroll disabled")
+	}
+
+	// PageDown advances by one viewport page.
+	page := m.eventPageSize()
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.eventCursor != page {
+		t.Fatalf("pgdown: expected cursor %d, got %d", page, m.eventCursor)
+	}
+
+	// PageUp returns to the top.
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyPgUp})
+	if m.eventCursor != 0 {
+		t.Fatalf("pgup: expected cursor 0, got %d", m.eventCursor)
+	}
+
+	// End jumps to the latest event and re-engages following.
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyEnd})
+	if m.eventCursor != 99 {
+		t.Fatalf("end: expected cursor 99, got %d", m.eventCursor)
+	}
+	if !m.autoScroll {
+		t.Fatal("end: expected auto-scroll re-enabled at latest event")
+	}
+}
+
+// TestGroupListPageAndJumpKeys verifies page-up/down and home/end navigation
+// over the log-group list when not tailing.
+func TestGroupListPageAndJumpKeys(t *testing.T) {
+	m := Model{
+		selected:      map[string]bool{},
+		expandedEvent: -1,
+		pollInterval:  defaultPollInterval,
+		width:         120,
+		height:        40,
+	}
+	for i := 0; i < 100; i++ {
+		m.logGroups = append(m.logGroups, logs.LogGroup{Name: fmt.Sprintf("/g/%03d", i)})
+	}
+
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyEnd})
+	if m.cursor != 99 {
+		t.Fatalf("end: expected cursor 99, got %d", m.cursor)
+	}
+
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyHome})
+	if m.cursor != 0 {
+		t.Fatalf("home: expected cursor 0, got %d", m.cursor)
+	}
+
+	page := m.listHeight()
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.cursor != page {
+		t.Fatalf("pgdown: expected cursor %d, got %d", page, m.cursor)
+	}
+
+	m = m.update(t, tea.KeyMsg{Type: tea.KeyPgUp})
+	if m.cursor != 0 {
+		t.Fatalf("pgup: expected cursor 0, got %d", m.cursor)
 	}
 }
 

--- a/internal/ui/s3/model.go
+++ b/internal/ui/s3/model.go
@@ -271,8 +271,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "pgup":
 			m.previewView.PageUp()
 			return m, nil
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.previewView.PageDown()
+			return m, nil
+		case "home":
+			m.previewView.GotoTop()
+			return m, nil
+		case "end":
+			m.previewView.GotoBottom()
 			return m, nil
 		case "p", "esc":
 			m.showPreview = false
@@ -303,6 +309,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
+	case "pgup":
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(m.maxCursorIndex())
 	case "enter":
 		return m.handleEnter()
 	case "backspace", "h", "esc":
@@ -451,6 +465,31 @@ func (m *Model) clampCursor() {
 		m.cursor = 0
 	}
 	m.ensureCursorVisible()
+}
+
+// jumpCursor moves the cursor to idx (clamped to the list bounds), updates
+// scroll visibility, and returns the command to refresh the right pane,
+// lazy-loading the next page of objects when the cursor lands near the end.
+// Used by page and home/end navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := m.maxCursorIndex()
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	cmd := m.onCursorMove()
+	if m.bucket != "" && m.nextToken != nil && !m.loadingMore && m.cursor >= len(m.filteredObjects())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreCmd())
+	}
+	return cmd
 }
 
 func (m Model) currentObjectKey() string {
@@ -898,7 +937,7 @@ func (m Model) StatusHelp() string {
 		return "enter/esc close search"
 	}
 	if m.showPreview {
-		return "↑↓ scroll, p/esc close preview"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, p/esc close preview"
 	}
 	if m.bucket == "" {
 		// Bucket list view

--- a/internal/ui/sqs/model.go
+++ b/internal/ui/sqs/model.go
@@ -190,8 +190,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "pgup":
 			m.expandedView.PageUp()
 			return m, nil
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.PageDown()
+			return m, nil
+		case "home":
+			m.expandedView.GotoTop()
+			return m, nil
+		case "end":
+			m.expandedView.GotoBottom()
 			return m, nil
 		case "esc", "q":
 			m.expandedMessage = -1
@@ -212,8 +218,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "pgup":
 			m.expandedView.PageUp()
 			return m, nil
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.PageDown()
+			return m, nil
+		case "home":
+			m.expandedView.GotoTop()
+			return m, nil
+		case "end":
+			m.expandedView.GotoBottom()
 			return m, nil
 		case "esc", "q":
 			m.expandedQueue = -1
@@ -236,6 +248,18 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.messageCursor++
 				m.ensureMessageCursorVisible()
 			}
+			return m, nil
+		case "pgup":
+			m.setMessageCursor(m.messageCursor - m.listHeight())
+			return m, nil
+		case "pgdown", "pgdn":
+			m.setMessageCursor(m.messageCursor + m.listHeight())
+			return m, nil
+		case "home":
+			m.setMessageCursor(0)
+			return m, nil
+		case "end":
+			m.setMessageCursor(len(m.messages) - 1)
 			return m, nil
 		case "enter", " ":
 			if len(m.messages) > 0 && m.messageCursor < len(m.messages) {
@@ -286,6 +310,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
+	case "pgup":
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(m.maxCursorIndex())
 	case "enter":
 		return m.handlePeek()
 	case " ":
@@ -466,6 +498,45 @@ func (m *Model) clampCursor() {
 	m.ensureCursorVisible()
 }
 
+// jumpCursor moves the queue cursor to idx (clamped to the list bounds),
+// updates scroll visibility, and returns the command to refresh attributes,
+// lazy-loading the next page when the cursor lands near the end. Used by page
+// and home/end navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := m.maxCursorIndex()
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	cmd := m.onCursorMove()
+	if m.nextToken != nil && !m.loadingMore && m.cursor >= len(m.filteredQueues())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreCmd())
+	}
+	return cmd
+}
+
+// setMessageCursor moves the peeked-message cursor to idx (clamped) and updates
+// scroll visibility. Used by page and home/end navigation in the message view.
+func (m *Model) setMessageCursor(idx int) {
+	last := len(m.messages) - 1
+	if idx > last {
+		idx = last
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	m.messageCursor = idx
+	m.ensureMessageCursorVisible()
+}
+
 func (m Model) currentQueueURL() string {
 	items := m.filteredQueues()
 	if len(items) == 0 || m.cursor >= len(items) {
@@ -590,7 +661,7 @@ func (m Model) StatusHelp() string {
 		return "enter/esc close search"
 	}
 	if m.expandedMessage >= 0 || m.expandedQueue >= 0 {
-		return "↑↓ scroll, esc close"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close"
 	}
 	if m.viewingMessages {
 		return "↑↓ move, enter expand, y copy body, ctrl+r refresh, esc back"

--- a/internal/ui/ssm/model.go
+++ b/internal/ui/ssm/model.go
@@ -195,8 +195,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "pgup":
 			m.expandedView.PageUp()
 			return m, nil
-		case "pgdn":
+		case "pgdown", "pgdn":
 			m.expandedView.PageDown()
+			return m, nil
+		case "home":
+			m.expandedView.GotoTop()
+			return m, nil
+		case "end":
+			m.expandedView.GotoBottom()
 			return m, nil
 		case "esc", "q":
 			m.expandedParam = -1
@@ -228,6 +234,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
+	case "pgup":
+		return m, m.jumpCursor(m.cursor - m.listHeight())
+	case "pgdown", "pgdn":
+		return m, m.jumpCursor(m.cursor + m.listHeight())
+	case "home":
+		return m, m.jumpCursor(0)
+	case "end":
+		return m, m.jumpCursor(m.maxCursorIndex())
 	case "enter", " ":
 		return m.handleEnter()
 	case "backspace", "h", "esc":
@@ -391,6 +405,31 @@ func (m *Model) clampCursor() {
 	m.ensureCursorVisible()
 }
 
+// jumpCursor moves the cursor to idx (clamped to the list bounds), updates
+// scroll visibility, and returns the command to refresh details, lazy-loading
+// the next page when the cursor lands near the end. Used by page and home/end
+// navigation.
+func (m *Model) jumpCursor(idx int) tea.Cmd {
+	maxIdx := m.maxCursorIndex()
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx == m.cursor {
+		return nil
+	}
+	m.cursor = idx
+	m.ensureCursorVisible()
+	cmd := m.onCursorMove()
+	if m.nextToken != nil && !m.loadingMore && m.cursor >= len(m.filteredParams())-5 {
+		m.loadingMore = true
+		return tea.Batch(cmd, m.loadMoreCmd())
+	}
+	return cmd
+}
+
 func (m Model) currentParamName() string {
 	items := m.filteredParams()
 	if len(items) == 0 || m.cursor >= len(items) {
@@ -536,7 +575,7 @@ func (m Model) StatusHelp() string {
 		return "enter/esc close search"
 	}
 	if m.expandedParam >= 0 {
-		return "↑↓ scroll, esc close"
+		return "↑↓ scroll, pgup/pgdn page, home/end top/bottom, esc close"
 	}
 	if len(m.path) == 0 {
 		return "↑↓ move, / search, enter open, y copy, ctrl+r refresh"


### PR DESCRIPTION
Add PageUp/PageDown (page the cursor) and Home/End (jump to
first/last) to every list view — logs groups, logs tail events, s3
buckets/objects, dynamodb tables/items, lambda, ssm, sqs queues/messages,
and ec2 — mirroring the existing j/k lazy-load behaviour via per-model
jumpCursor helpers. Scrollable popups and the s3 preview gain Home/End
(GotoTop/GotoBottom) alongside page keys.

Fix a latent bug: popups bound "pgdn", but bubbletea emits "pgdown" for
PageDown, so PageDown never fired. Both strings are now handled.

In DynamoDB, PageUp/PageDown previously scrolled the right-hand detail
pane; they now page the list for consistency with every other view (the
detail pane shows a truncation hint, and the expanded popup remains fully
scrollable). Update help text, docs, and add navigation tests.