### PR TITLE
fix(ui): persist region selection immediately on change

### DIFF
--- a/cmd/sacha/main.go
+++ b/cmd/sacha/main.go
@@ -114,7 +114,17 @@ func run(ctx context.Context, flags cliFlags) error {
 		runtime.Service = config.DefaultService()
 	}
 
-	appModel, err := appui.NewModel(loader, services, runtime, awsCfg, &log.Logger)
+	// persist writes the latest selection to disk immediately so a region or
+	// service change survives abnormal termination (terminal closed, SIGHUP,
+	// crash), not just a clean exit.
+	persist := func(rt config.RuntimeConfig) error {
+		fileCfg.LastProfile = rt.Profile
+		fileCfg.LastRegion = rt.Region
+		fileCfg.LastService = rt.Service
+		return config.Save(cfgPath, fileCfg)
+	}
+
+	appModel, err := appui.NewModel(loader, services, runtime, awsCfg, &log.Logger, persist)
 	if err != nil {
 		return err
 	}
@@ -129,10 +139,7 @@ func run(ctx context.Context, flags cliFlags) error {
 		runtime = finalModel.Runtime()
 	}
 
-	fileCfg.LastProfile = runtime.Profile
-	fileCfg.LastRegion = runtime.Region
-	fileCfg.LastService = runtime.Service
-	return config.Save(cfgPath, fileCfg)
+	return persist(runtime)
 }
 
 func sortedServiceNames(services map[string]awsx.Service) string {

--- a/internal/ui/app/model.go
+++ b/internal/ui/app/model.go
@@ -33,12 +33,18 @@ type Model struct {
 	regionSelector  optionSelector
 	serviceSelector optionSelector
 
+	// persist saves the runtime selection (region/profile/service) to disk.
+	// It is invoked immediately after a selection change so the choice
+	// survives abnormal termination (terminal closed, SIGHUP, crash), not
+	// just a clean exit. May be nil in tests.
+	persist func(config.RuntimeConfig) error
+
 	width  int
 	height int
 	status string
 }
 
-func NewModel(loader awsx.Loader, services map[string]awsx.Service, runtime config.RuntimeConfig, cfg sdkaws.Config, logger *zerolog.Logger) (Model, error) {
+func NewModel(loader awsx.Loader, services map[string]awsx.Service, runtime config.RuntimeConfig, cfg sdkaws.Config, logger *zerolog.Logger, persist func(config.RuntimeConfig) error) (Model, error) {
 	// Ensure runtime.Region is always set when cfg.Region is available.
 	if runtime.Region == "" && cfg.Region != "" {
 		runtime.Region = cfg.Region
@@ -54,6 +60,7 @@ func NewModel(loader awsx.Loader, services map[string]awsx.Service, runtime conf
 		cache:      cache.New(),
 		accountID:  accountID,
 		monitoring: monitoring,
+		persist:    persist,
 	}
 	m.regionSelector = newOptionSelectorWithViews(awsRegions, commonRegions)
 	m.serviceSelector = newOptionSelector(serviceNames(services))
@@ -202,7 +209,20 @@ func (m *Model) changeRegion(region string) (tea.Cmd, error) {
 			return tea.WindowSizeMsg{Width: m.width, Height: m.height}
 		})
 	}
+	m.persistRuntime()
 	return tea.Batch(cmds...), nil
+}
+
+// persistRuntime writes the current runtime selection to disk via the persist
+// callback, so the choice is remembered even if the app is terminated
+// abnormally. Save failures are logged but never block the UI.
+func (m *Model) persistRuntime() {
+	if m.persist == nil {
+		return
+	}
+	if err := m.persist(m.runtime); err != nil && m.logger != nil {
+		m.logger.Error().Err(err).Msg("failed to persist runtime config")
+	}
 }
 
 func emptyIf(value, fallback string) string {
@@ -319,6 +339,7 @@ func (m Model) handleServiceSelector(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = err.Error()
 			return m, cmd
 		}
+		m.persistRuntime()
 		initCmds := []tea.Cmd{}
 		if m.service != nil {
 			initCmds = append(initCmds, m.service.Init())

--- a/internal/ui/app/model_test.go
+++ b/internal/ui/app/model_test.go
@@ -294,13 +294,88 @@ func TestNewModelSyncsRuntimeRegionFromConfig(t *testing.T) {
 		Region: "eu-west-1",
 	}
 
-	m, err := NewModel(newFakeLoader(), services, runtime, cfg, nil)
+	m, err := NewModel(newFakeLoader(), services, runtime, cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("NewModel: %v", err)
 	}
 
 	if m.runtime.Region != "eu-west-1" {
 		t.Errorf("NewModel should sync runtime.Region from cfg.Region: got %q, want %q", m.runtime.Region, "eu-west-1")
+	}
+}
+
+func TestModelChangeRegionPersistsImmediately(t *testing.T) {
+	// Region selection must be written to disk as soon as it changes, so it
+	// survives abnormal termination rather than only a clean exit.
+	services := map[string]awsx.Service{
+		"mock": mockService{},
+	}
+
+	runtime := appconfig.RuntimeConfig{
+		Region:  "us-east-1",
+		Service: "mock",
+	}
+	cfg := aws.Config{Region: "us-east-1"}
+
+	var saved []appconfig.RuntimeConfig
+	persist := func(rt appconfig.RuntimeConfig) error {
+		saved = append(saved, rt)
+		return nil
+	}
+
+	m := Model{
+		loader:   newFakeLoader(),
+		services: services,
+		runtime:  runtime,
+		cfg:      cfg,
+		cache:    cache.New(),
+		persist:  persist,
+	}
+	m.regionSelector = newOptionSelectorWithViews(awsRegions, commonRegions)
+	m.serviceSelector = newOptionSelector(serviceNames(services))
+	if err := m.activateService("mock"); err != nil {
+		t.Fatalf("activateService: %v", err)
+	}
+
+	if _, err := m.changeRegion("eu-west-1"); err != nil {
+		t.Fatalf("changeRegion: %v", err)
+	}
+
+	if len(saved) != 1 {
+		t.Fatalf("persist called %d times, want 1", len(saved))
+	}
+	if saved[0].Region != "eu-west-1" {
+		t.Errorf("persisted region = %q, want %q", saved[0].Region, "eu-west-1")
+	}
+}
+
+func TestModelChangeRegionFailureDoesNotPersist(t *testing.T) {
+	// A failed region change must not write anything to disk.
+	services := map[string]awsx.Service{
+		"mock": mockService{},
+	}
+	runtime := appconfig.RuntimeConfig{Region: "us-east-1", Service: "mock"}
+
+	var calls int
+	m := Model{
+		loader:   newFakeLoader(),
+		services: services,
+		runtime:  runtime,
+		cfg:      aws.Config{Region: "us-east-1"},
+		cache:    cache.New(),
+		persist:  func(appconfig.RuntimeConfig) error { calls++; return nil },
+	}
+	m.regionSelector = newOptionSelectorWithViews(awsRegions, commonRegions)
+	m.serviceSelector = newOptionSelector(serviceNames(services))
+	if err := m.activateService("mock"); err != nil {
+		t.Fatalf("activateService: %v", err)
+	}
+
+	if _, err := m.changeRegion(""); err == nil {
+		t.Fatal("changeRegion('') should fail")
+	}
+	if calls != 0 {
+		t.Errorf("persist called %d times on failure, want 0", calls)
 	}
 }
 


### PR DESCRIPTION
Region (and service) selection was only written to the config file on a
clean exit. When the TUI was terminated abnormally (terminal closed,
SIGHUP, kill, or crash), the exit path never ran and the selection was
lost, so the chosen region was not remembered on the next launch.

Plumb a persist callback into the app Model and invoke it right after a
successful region or service change, writing LastRegion/LastProfile/
LastService to disk immediately. The clean-exit save is retained as a
final sync via the same callback. Save failures are logged, never
blocking the UI.